### PR TITLE
Fix for instantiation of extensibility handlers

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Extensibility/ExtensibilityManager.cs
+++ b/src/lib/PnP.Framework/Provisioning/Extensibility/ExtensibilityManager.cs
@@ -5,8 +5,6 @@ using PnP.Framework.Provisioning.ObjectHandlers;
 using PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Loader;
 
 namespace PnP.Framework.Provisioning.Extensibility
 {
@@ -255,13 +253,7 @@ namespace PnP.Framework.Provisioning.Extensibility
             if (!handlerCache.ContainsKey(handler))
             {
 
-                // Does not work as the assembly was not loaded upfront
-                // See https://jeremybytes.blogspot.com/2020/01/using-typegettype-with-net-core.html for some more context
-                //var _instance = Activator.CreateInstance(handler.GetType());
-
-                var handlerAssemblyPath = AppDomain.CurrentDomain.BaseDirectory + handler.Assembly + ".dll";
-                var handlerAssembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(handlerAssemblyPath);
-                var handlerType = handlerAssembly.ExportedTypes.Where(p => p.FullName == handler.Type).FirstOrDefault();
+                var handlerType = Type.GetType($"{handler.Type}, {handler.Assembly}", true);
                 var _instance = Activator.CreateInstance(handlerType);
 
                 handlerCache.Add(handler, _instance);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for instantiating extensibility handlers.
The previous code assumed that the extensibility handler assembly was located in the same folder as the executing assembly and that the handler assembly name specified in the HandlerType attribute for the Provider in the provisioning template was in its short form. If it was specified as a fully qualified name it would look for a file named something like "TestExtensibilityHandler, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null.xml". We would also not be able to load extensibility handlers from somewhere else than the same folder as the executing assembly.
With this fix handlers located in the same folder as the executing assembly will be loaded and we can both pre-load assemblies and use the AssemblyLoadContext.Default.Resolving event to load the handlers. It has been tested with all of them.

Credits to @pschaeflein who made the original PR [https://github.com/pnp/PnP-Sites-Core/pull/2764](https://github.com/pnp/PnP-Sites-Core/pull/2764). I just wanted this to get in the preview as soon as possible as we are in a big need for this.

