### PR TITLE
Fix some warnings related to XML comments

### DIFF
--- a/src/lib/PnP.Framework/Modernization/Cache/CacheManager.cs
+++ b/src/lib/PnP.Framework/Modernization/Cache/CacheManager.cs
@@ -1221,7 +1221,6 @@ namespace PnP.Framework.Modernization.Cache
         /// Get Term Path by ID
         /// </summary>
         /// <param name="context"></param>
-        /// <param name="termData"></param>
         /// <returns></returns>
         public void StoreTermSetTerms(ClientContext context, Guid termSetId, Guid sourceSspId, bool isSP2010, bool isSourceTerm)
         {

--- a/src/lib/PnP.Framework/Modernization/Caml/FieldReference.cs
+++ b/src/lib/PnP.Framework/Modernization/Caml/FieldReference.cs
@@ -109,7 +109,7 @@
         }
 
         /// <summary>
-        /// Creates an instance of FieldReference with the initial specified <param name="name"></param>. 
+        /// Creates an instance of FieldReference with the initial specified <paramref name="name"/>. 
         /// </summary>
         /// <param name="name">Internal name of the field.</param>
         public FieldReference(string name)

--- a/src/lib/PnP.Framework/Modernization/Caml/ListPropertyValueItem.cs
+++ b/src/lib/PnP.Framework/Modernization/Caml/ListPropertyValueItem.cs
@@ -21,7 +21,7 @@
 
         /// <summary>
         /// True to insert break-line tags into the text stream and to
-        /// replace multiple spaces with a nonbreaking space (&nbsp;).
+        /// replace multiple spaces with a nonbreaking space (&amp;nbsp;).
         /// </summary>
         public bool? AutoNewLine { get; set; }
 

--- a/src/lib/PnP.Framework/Modernization/Extensions/StringExtensions.cs
+++ b/src/lib/PnP.Framework/Modernization/Extensions/StringExtensions.cs
@@ -41,8 +41,6 @@ namespace PnP.Framework.Modernization.Extensions
         /// Removes a relative section of by string where context not available
         /// </summary>
         /// <param name="value"></param>
-        /// <param name="seperator"></param>
-        /// <param name="instanceFrom"></param>
         /// <returns></returns>
         public static string StripRelativeUrlSectionString(this string value)
         {
@@ -79,7 +77,7 @@ namespace PnP.Framework.Modernization.Extensions
         /// <summary>
         /// Gets base url from string
         /// </summary>
-        /// <param name="sourceSite"></param>
+        /// <param name="url"></param>
         /// <returns></returns>
         public static string GetBaseUrl(this string url)
         {

--- a/src/lib/PnP.Framework/Modernization/Functions/BuiltIn.cs
+++ b/src/lib/PnP.Framework/Modernization/Functions/BuiltIn.cs
@@ -971,7 +971,7 @@ namespace PnP.Framework.Modernization.Functions
         /// <summary>
         /// Throws an exception when link to .aspx file.
         /// </summary>
-        /// <param name="listId">Link value if set</param>
+        /// <param name="contentLink">Link value if set</param>
         /// <returns>Unused variable</returns>
         [FunctionDocumentation(Description = "Throws an exception when link to .aspx file.",
                                Example = "{Temp} = ContentEmbedCrossSiteCheck({ContentLink})")]
@@ -1063,10 +1063,6 @@ namespace PnP.Framework.Modernization.Functions
         /// <summary>
         /// Maps the user documents web part data into a properties collection and supporting serverProcessedContent nodes for the content rollup (= Highlighted Content) web part
         /// </summary>
-        /// <param name="dataProviderJson"></param>
-        /// <param name="selectedPropertiesJson"></param>
-        /// <param name="resultsPerPage"></param>
-        /// <param name="renderTemplateId"></param>
         /// <returns>A properties collection and supporting serverProcessedContent nodes for the content rollup (= Highlighted Content) web part</returns>
         [FunctionDocumentation(Description = "Maps the user documents web part data into a properties collection and supporting serverProcessedContent nodes for the content rollup (= Highlighted Content) web part",
                                    Example = "SiteDocumentsToHighlightedContentProperties()")]
@@ -1412,7 +1408,7 @@ namespace PnP.Framework.Modernization.Functions
         /// <summary>
         /// Uses the UseCommunityScriptEditor mapping property provided via the PageTransformationInformation instance to determine the mapping
         /// </summary>
-        /// <param name="useQuickLinks">The UseCommunityScriptEditor mapping property provided via the PageTransformationInformation instance</param>
+        /// <param name="useCommunityScriptEditor">The UseCommunityScriptEditor mapping property provided via the PageTransformationInformation instance</param>
         /// <returns>Whether to transform via the community script editor web part</returns>
         [SelectorDocumentation(Description = "Uses the UseCommunityScriptEditor mapping property provided via the PageTransformationInformation instance to determine the mapping",
                                Example = "ScriptEditorSelector({UseCommunityScriptEditor})")]

--- a/src/lib/PnP.Framework/Modernization/Publishing/PageLayoutAnalyser.cs
+++ b/src/lib/PnP.Framework/Modernization/Publishing/PageLayoutAnalyser.cs
@@ -359,7 +359,6 @@ namespace PnP.Framework.Modernization.Publishing
         /// <summary>
         /// Get Metadata mapping from the page layout associated content type
         /// </summary>
-        /// <param name="contentTypeId">Id of the content type</param>
         internal MetaDataField[] ExtractMetaDataFromPageLayoutAssociatedContentType(FieldCollection spFields, List<WebPartField> webPartFields, Header extractedHeader)
         {
             List<MetaDataField> fields = new List<MetaDataField>();
@@ -427,7 +426,7 @@ namespace PnP.Framework.Modernization.Publishing
         /// </summary>
         /// <param name="pageLayout"></param>
         /// <returns>
-        ///     List<Tuple<string, string>>
+        ///     List&lt;Tuple&lt;string, string&gt;&gt;
         ///     Item1 = tagprefix
         ///     Item2 = Namespace
         /// </returns>
@@ -812,8 +811,7 @@ namespace PnP.Framework.Modernization.Publishing
         /// <summary>
         /// Sets the page layout header field defaults
         /// </summary>
-        /// <param name="oobPageLayoutDefaults"></param>
-        /// <param name="layoutMapping"></param>
+        /// <param name="spFields"></param>
         private Header ExtractPageHeaderFromPageLayoutAssociatedContentType(FieldCollection spFields)
         {
             try

--- a/src/lib/PnP.Framework/Modernization/Publishing/PublishingBuiltIn.cs
+++ b/src/lib/PnP.Framework/Modernization/Publishing/PublishingBuiltIn.cs
@@ -25,9 +25,7 @@ namespace PnP.Framework.Modernization.Publishing
         /// <summary>
         /// Instantiates the base builtin function library
         /// </summary>
-        /// <param name="pageClientContext">ClientContext object for the site holding the page being transformed</param>
         /// <param name="sourceClientContext">The ClientContext for the source </param>
-        /// <param name="clientSidePage">Reference to the client side page</param>
         public PublishingBuiltIn(BaseTransformationInformation baseTransformationInformation, ClientContext sourceClientContext, ClientContext targetClientContext, IList<ILogObserver> logObservers = null) : base(sourceClientContext)
         {
             if (logObservers != null)

--- a/src/lib/PnP.Framework/Modernization/Telemetry/Observers/ConsoleObserver.cs
+++ b/src/lib/PnP.Framework/Modernization/Telemetry/Observers/ConsoleObserver.cs
@@ -13,7 +13,7 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         private string _pageBeingTransformed;
 
         /// <summary>
-        /// Get the single List<LogEntry> instance, singleton pattern
+        /// Get the single List&lt;LogEntry&gt; instance, singleton pattern
         /// </summary>
         public static List<Tuple<LogLevel, LogEntry>> Logs
         {
@@ -122,7 +122,7 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         /// <summary>
         /// Sets the id of the page that's being transformed
         /// </summary>
-        /// <param name="pageName">Id of the page</param>
+        /// <param name="pageId">Id of the page</param>
         public void SetPageId(string pageId)
         {
             this._pageBeingTransformed = pageId;

--- a/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownObserver.cs
+++ b/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownObserver.cs
@@ -67,7 +67,7 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         #endregion
 
         /// <summary>
-        /// Get the single List<LogEntry> instance, singleton pattern
+        /// Get the single List&lt;LogEntry&gt; instance, singleton pattern
         /// </summary>
         public static List<Tuple<LogLevel, LogEntry>> Logs
         {
@@ -316,7 +316,7 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         /// Generate a summary report
         /// </summary>
         /// <param name="report"></param>
-        /// <param name="summeries"></param>
+        /// <param name="summaries"></param>
         private void GenerateIssueSummaryReport(StringBuilder report, List<TransformationLogAnalysis> summaries)
         {
             StringBuilder errorSummary = new StringBuilder();

--- a/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownToSharePoint.cs
+++ b/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownToSharePoint.cs
@@ -22,7 +22,6 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         /// Constructor to save a markdown report to SharePoint Modern Site Assets library
         /// </summary>
         /// <param name="context"></param>
-        /// <param name="libraryName"></param>
         /// <param name="folderName"></param>
         public MarkdownToSharePointObserver(ClientContext context, string folderName = "Transformation-Reports", string fileName = "", bool includeDebugEntries = false, bool includeVerbose = false) : base(fileName, null, includeDebugEntries, includeVerbose)
         {

--- a/src/lib/PnP.Framework/Modernization/Transform/AssetTransfer.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/AssetTransfer.cs
@@ -415,8 +415,7 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Stores an asset transfer reference
         /// </summary>
-        /// <param name="assetTransferReferenceEntity"></param>
-        /// <param name="update"></param>
+        /// <param name="assetTransferredEntity"></param>
         public void StoreAssetTransferred(AssetTransferredEntity assetTransferredEntity)
         {
             // Using the Cache Manager store the asset transfer references

--- a/src/lib/PnP.Framework/Modernization/Transform/BasePageTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/BasePageTransformator.cs
@@ -1296,7 +1296,6 @@ namespace PnP.Framework.Modernization.Transform
         /// Loads the User Mapping Files
         /// </summary>
         /// <param name="baseTransformationInformation"></param>
-        /// <param name="sourceClientContext"></param>
         internal void InitializeUserMapping(BaseTransformationInformation baseTransformationInformation)
         {
             // Create an instance of the user transformation class

--- a/src/lib/PnP.Framework/Modernization/Transform/BaseTransform.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/BaseTransform.cs
@@ -89,7 +89,7 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Notifies the observers of error messages
         /// </summary>
-        /// <param name="logEntry">The message.</param>
+        /// <param name="message">The message.</param>
         public void LogError(string message, string heading = "", Exception exception = null, bool ignoreException = false, bool isCriticalException = false)
         {
             StackTrace stackTrace = new StackTrace();
@@ -109,7 +109,7 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Notifies the observers of info messages
         /// </summary>
-        /// <param name="logEntry">The message.</param>
+        /// <param name="message">The message.</param>
         public void LogInfo(string message, string heading = "", LogEntrySignificance significance = LogEntrySignificance.None)
         {
             StackTrace stackTrace = new StackTrace();
@@ -121,7 +121,7 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Notifies the observers of warning messages
         /// </summary>
-        /// <param name="logEntry">The message.</param>
+        /// <param name="message">The message.</param>
         public void LogWarning(string message, string heading = "")
         {
             StackTrace stackTrace = new StackTrace();
@@ -133,7 +133,7 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Notifies the observers of debug messages
         /// </summary>
-        /// <param name="logEntry">The message.</param>
+        /// <param name="message">The message.</param>
         public void LogDebug(string message, string heading = "")
         {
             StackTrace stackTrace = new StackTrace();

--- a/src/lib/PnP.Framework/Modernization/Transform/ContentByQuerySearchTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/ContentByQuerySearchTransformator.cs
@@ -453,7 +453,6 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Generate contentrollup (=highlighted content) web part properties coming from a content by search web part
         /// </summary>
-        /// <param name="cbs">Properties coming from the content by search web part</param>
         /// <returns>Properties for highlighted content web part</returns>
         public ContentByQuerySearchTransformatorResult TransformUserDocuments()
         {

--- a/src/lib/PnP.Framework/Modernization/Transform/TermTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/TermTransformator.cs
@@ -76,9 +76,9 @@ namespace PnP.Framework.Modernization.Transform
         /// Transforms a collection of terms in a dictionary
         /// </summary>
         /// <returns>
-        ///     Tuple<TaxonomyFieldValueCollection,List<TaxonomyFieldValue>> 
+        ///     Tuple&lt;TaxonomyFieldValueCollection,List&lt;TaxonomyFieldValue&gt;&gt; 
         ///     TaxonomyFieldValueCollection - Original Array
-        ///     List<TaxonomyFieldValue> - Items to remove as they are not resolved
+        ///     List&lt;TaxonomyFieldValue&gt; - Items to remove as they are not resolved
         /// </returns>
         public Tuple<TaxonomyFieldValueCollection,List<TaxonomyFieldValue>>  TransformCollection(TaxonomyFieldValueCollection taxonomyFieldValueCollection)
         {
@@ -304,8 +304,7 @@ namespace PnP.Framework.Modernization.Transform
         /// </summary>
         /// <param name="subTermPath"></param>
         /// <param name="term"></param>
-        /// <param name="includeId"></param>
-        /// <param name="delimiter"></param>
+        /// <param name="termSetId"></param>
         /// <param name="clientContext"></param>
         /// <returns></returns>
         /// Reference: https://github.com/SharePoint/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Extensions/TaxonomyExtensions.cs

--- a/src/lib/PnP.Framework/Modernization/Transform/UserTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/UserTransformator.cs
@@ -129,7 +129,7 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Remap principal to target principal
         /// </summary>
-        /// <param name="principal"></param>
+        /// <param name="principalInput"></param>
         /// <returns>Principal for the target site</returns>
         public string RemapPrincipal(string principalInput)
         {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -341,7 +341,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                     resourceEntries.Add(new Tuple<string, uint, string>(key.ToString(), (uint)localizationEntry.LCID, value.ToString().Replace("\"", "&quot;")));
                                 }
 
-                                /**
+                                /*
                                 // are we talking a resx file or a json file?
                                 if (filePath.ToLower().EndsWith(".resx"))
                                 {

--- a/src/lib/PnP.Framework/Utilities/TokenHelper.cs
+++ b/src/lib/PnP.Framework/Utilities/TokenHelper.cs
@@ -806,6 +806,7 @@ namespace PnP.Framework.Utilities
         {
         }
 
+        /*
         /// <summary>
         /// Constructor for SharePointContextToken class
         /// </summary>
@@ -816,10 +817,11 @@ namespace PnP.Framework.Utilities
         /// <param name="claims">IEnumerable of JsonWebTokenClaim object</param>
         /// <param name="issuerToken">SecurityToken object</param>
         /// <param name="actorToken">JsonWebSecurityToken object</param>
-        //public SharePointContextToken(string issuer, string audience, DateTime validFrom, DateTime validTo, IEnumerable<Claim> claims, SecurityToken issuerToken, JwtSecurityToken actorToken)
-        //    : base(issuer, audience, claims, validFrom, validTo, issuerToken, actorToken)
-        //{
-        //}
+        public SharePointContextToken(string issuer, string audience, DateTime validFrom, DateTime validTo, IEnumerable<Claim> claims, SecurityToken issuerToken, JwtSecurityToken actorToken)
+            : base(issuer, audience, claims, validFrom, validTo, issuerToken, actorToken)
+        {
+        }
+        */
 
         /// <summary>
         /// Constructor for SharePointContextToken class


### PR DESCRIPTION
Fixes the following warnings related to XML comments:
- CS1572 "XML comment on 'construct' has a param tag for 'parameter', but there is no parameter by that name" https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1572
- CS1587 "XML comment is not placed on a valid language element" https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1587
- CS1570 "XML comment on 'construct' has badly formed XML — 'reason'" https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1570

On top of these there are a lot of warnings about parameters missing in the XML comments. Is there any meaning in adding those without any actual comment in another PR or is it better to keep the warnings as reminder ?