### PR TITLE
fix url encoding issue when writing href values to client_LocationBasedDefaults.html as part of SetDefaultColumnValuesImplementation()

### DIFF
--- a/src/lib/PnP.Framework.Test/Utilities/UrlUtilityTests.cs
+++ b/src/lib/PnP.Framework.Test/Utilities/UrlUtilityTests.cs
@@ -36,5 +36,16 @@ namespace PnP.Framework.Test.AppModelExtensions
             var invalidString = "a#%*\\:<>?/+|b";
             Assert.AreEqual("a---------------------------------b", invalidString.ReplaceInvalidUrlChars("---"));
         }
+
+        [TestMethod]
+        public void UrlPathEncodePerformsUrlEncodingButLeavesSlashesAlone()
+        {
+            var input = "/sites/site001/document library/folder abc";
+            var expected = "/sites/site001/document%20library/folder%20abc";
+            
+            var actual = input.UrlPathEncode();
+
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/src/lib/PnP.Framework/Extensions/ListExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ListExtensions.cs
@@ -1645,7 +1645,7 @@ namespace Microsoft.SharePoint.Client
                         path = path.Equals("/") ? list.RootFolder.ServerRelativeUrl : UrlUtility.Combine(list.RootFolder.ServerRelativeUrl, path);
                         // Find all in the same path:
                         var defaultColumnValuesInSamePath = columnValues.Where(x => x.FolderRelativePath == defaultColumnValue.FolderRelativePath);
-                        path = System.Web.HttpUtility.UrlEncode(path);
+                        path = path.UrlPathEncode();
 
                         var xATag = new XElement("a", new XAttribute("href", path));
 

--- a/src/lib/PnP.Framework/Utilities/UrlUtility.cs
+++ b/src/lib/PnP.Framework/Utilities/UrlUtility.cs
@@ -143,14 +143,24 @@ namespace PnP.Framework.Utilities
             return ReplaceInvalidUrlChars(content, "");
         }
         /// <summary>
-        /// Replaces invalid charcters with other characters
+        /// Replaces invalid characters with other characters
         /// </summary>
         /// <param name="content">Url value</param>
         /// <param name="replacer">string need to replace with invalid characters</param>
-        /// <returns>Returns replaced invalid charcters from URL</returns>
+        /// <returns>Returns replaced invalid characters from URL</returns>
         public static string ReplaceInvalidUrlChars(this string content, string replacer)
         {
             return new Regex(INVALID_CHARS_REGEX).Replace(content, replacer);
+        }
+
+        /// <summary>
+        /// Encodes URL encoded in a way that SharePoint expected URLs to be encoded in client_LocationBasedDefaults.html
+        /// </summary>
+        /// <param name="content">Url value</param>
+        /// <returns>Returns URL encoded in a way that SharePoint expected URLs to be encoded in client_LocationBasedDefaults.html</returns>
+        public static string UrlPathEncode(this string content)
+        {
+            return System.Web.HttpUtility.UrlPathEncode(content);
         }
 
         /// <summary>


### PR DESCRIPTION
SharePoint is expecting a specific type of URL Encoding for href values in client_LocationBasedDefaults.html (the file which SharePoint produces to store the "Column default settings" for a document library) as can be observed when inspecting the file in the /Forms directory for the library after configuring defaults through the SharePoint UI. The type of encoding used by SharePoint leaves slashes alone and replaces spaces with %20 rather than '+' signs.

This PR addresses a bug in pnp framework (inside the SetDefaultColumnValuesImplementation method) where System.Web.HttpUtility.UrlEncode(path) is used to encode href values, which does not result in the type of encoding expected by SharePoint.

