### PR TITLE
Added ClientContextType.AzureOnBehalfOf

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -267,7 +267,7 @@ namespace PnP.Framework
         /// </summary>
         /// <param name="clientId">The client id of the Azure AD application to use for authentication.</param>
         /// <param name="clientSecret">The client secret of the Azure AD application to use for authentication.</param>
-        /// <param name="tenantId">The if of the tenant, if a specific tenant is to be used for authentication.</param>
+        /// <param name="tenantId">Optional tenant id or tenant url.</param>
         /// <param name="azureEnvironment">The azure environment to use. Defaults to AzureEnvironment.Production</param>
         /// <param name="userAssertion">The user assertion (token) of the user on whose behalf to acquire the context</param>
         /// <param name="tokenCacheCallback"></param>

--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Identity.Client;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.SharePoint.Client;
 using PnP.Framework.Diagnostics;
 using PnP.Framework.Utilities.Context;

--- a/src/lib/PnP.Framework/Utilities/Context/ClientContextType.cs
+++ b/src/lib/PnP.Framework/Utilities/Context/ClientContextType.cs
@@ -6,6 +6,7 @@
         AzureADCredentials = 1,
         AzureADCertificate = 2,
         Cookie = 3,
-        AzureADInteractive = 4
+        AzureADInteractive = 4,
+        AzureOnBehalfOf = 5
     }
 }


### PR DESCRIPTION


Q | A
-- | --
Bug fix? | no
New feature? | yes
New sample? | no
Related issues? | #13

**What is in this Pull Request?** 

The pull request is made as a consequence of  issue #13. The PR contains the code to facilitate retrieval of client context by using Enterprise Application (`clientid,clientsected`) with granted admin consent to acquire tokens on behalf of the user (`userAssertion`).

The added constructor uses `(string clientId, string clientSecret, UserAssertion userAssertion,...)` as parameters. At first the `UserAssertion ` was attempted to be used as `string token` parameter which is then constructed into `UserAssertion`.  It did not work, because there already are constructors using 3-4 string parameters. Therefore `Microsoft.Identity.Client.UserAssertion `is explicitly used.

The examplary use of the retrieval could be in the form of:
```
public ClientContext GetContext(HttpRequest request, string siteUrl)
{
    var token = request.Headers["Authorization"].ToString().Remove(0, "Bearer ".Length);
    var userAssetion = new UserAssertion(token);
    using var authManager = new PnP.Framework.AuthenticationManager("{clientApplicationId}", "{clientApplicationSecret}", userAssetion);

    return authManager.GetContext(siteUrl);
}
```
