### PR TITLE
Added Azure OnBehalfOf token acquiring

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -85,6 +85,7 @@ namespace PnP.Framework
         private readonly ClientContextType authenticationType;
         private readonly string username;
         private readonly SecureString password;
+        private readonly UserAssertion assertion;
 
         internal string RedirectUrl { get; set; }
 
@@ -260,6 +261,35 @@ namespace PnP.Framework
 
             authenticationType = ClientContextType.AzureADCertificate;
         }
+
+        /// <summary>
+        /// Creates a new instance of the Authentication Manager to acquire authenticated ClientContext.
+        /// </summary>
+        /// <param name="clientId">The client id of the Azure AD application to use for authentication.</param>
+        /// <param name="clientSecret">The client secret of the Azure AD application to use for authentication.</param>
+        /// <param name="tenantId">Optional tenant id or tenant url</param>
+        /// <param name="azureEnvironment">The azure environment to use. Defaults to AzureEnvironment.Production</param>
+        /// <param name="userAssertion">The user assertion (token) of the user on whose behalf to acquire the context</param>
+        /// <param name="tokenCacheCallback"></param>
+        public AuthenticationManager(string clientId, string clientSecret, UserAssertion userAssertion, string tenantId = null, AzureEnvironment azureEnvironment = AzureEnvironment.Production, Action<ITokenCache> tokenCacheCallback = null) : this()
+        {
+            
+
+            var azureADEndPoint = GetAzureADLoginEndPoint(azureEnvironment);
+
+            var builder = ConfidentialClientApplicationBuilder.Create(clientId).WithClientSecret(clientSecret).WithAuthority($"{azureADEndPoint}/organizations/");
+            if (!string.IsNullOrEmpty(tenantId))
+            {
+                builder = builder.WithTenantId(tenantId);
+            }
+
+            this.assertion = userAssertion;
+            confidentialClientApplication = builder.Build();
+
+            // register tokencache if callback provided
+            tokenCacheCallback?.Invoke(confidentialClientApplication.UserTokenCache);
+            authenticationType = ClientContextType.AzureOnBehalfOf;
+        }
         #endregion
 
         /// <summary>
@@ -403,6 +433,24 @@ namespace PnP.Framework
                         }
                         break;
                     }
+                case ClientContextType.AzureOnBehalfOf:
+                    {
+                        var accounts = await confidentialClientApplication.GetAccountsAsync();
+
+                        try
+                        {
+                            authResult = await confidentialClientApplication.AcquireTokenSilent(scopes, accounts.First()).ExecuteAsync();
+                        }
+                        catch
+                        {
+                            authResult = await confidentialClientApplication.AcquireTokenOnBehalfOf(scopes, assertion).ExecuteAsync();
+                        }
+                        if (authResult.AccessToken != null)
+                        {
+                            return BuildClientContext(confidentialClientApplication, siteUrl, scopes, authenticationType);
+                        }
+                        break;
+                    }
             }
             return null;
         }
@@ -441,6 +489,11 @@ namespace PnP.Framework
                         case ClientContextType.AzureADInteractive:
                             {
                                 ar = ((IPublicClientApplication)application).AcquireTokenInteractive(scopes).ExecuteAsync().GetAwaiter().GetResult();
+                                break;
+                            }
+                        case ClientContextType.AzureOnBehalfOf:
+                            {
+                                ar = ((IConfidentialClientApplication)application).AcquireTokenOnBehalfOf(scopes, this.assertion).ExecuteAsync().GetAwaiter().GetResult();
                                 break;
                             }
 

--- a/src/lib/PnP.Framework/Utilities/Context/ClientContextType.cs
+++ b/src/lib/PnP.Framework/Utilities/Context/ClientContextType.cs
@@ -6,6 +6,7 @@
         AzureADCredentials = 1,
         AzureADCertificate = 2,
         Cookie = 3,
-        AzureADInteractive = 4
+        AzureADInteractive = 4,
+        AzureOnBehalfOf = 5
     }
 }


### PR DESCRIPTION
Q | A
-- | --
Bug fix? | no
New feature? | yes
New sample? | no
Related issues? | #13

**What is in this Pull Request?** 

The pull request is made as a consequence of  issue #13. The PR contains the code to facilitate retrieval of client context by using Enterprise Application (`clientid,clientsected`) with granted admin consent to acquire tokens on behalf of the user (`userAssertion`).

The added constructor uses `(string clientId, string clientSecret, UserAssertion userAssertion,...)` as parameters. At first the `UserAssertion ` was attempted to be used as `string token` parameter which is then constructed into `UserAssertion`.  It did not work, because there already are constructors using 3-4 string parameters. Therefore `Microsoft.Identity.Client.UserAssertion `is explicitly used.

The examplary use of the retrieval could be in the form of:
```
public ClientContext GetContext(HttpRequest request, string siteUrl)
{
    var token = request.Headers["Authorization"].ToString().Remove(0, "Bearer ".Length);
    var userAssertion = new UserAssertion(token);
    using var authManager = new PnP.Framework.AuthenticationManager("{clientApplicationId}", "{clientApplicationSecret}", userAssertion);

    return authManager.GetContext(siteUrl);
}
```

P.S. This is a repeated PR, because I have managed to accidentally corrupt line endings in the closed PR