### PR TITLE
Add some missing XML comments

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -169,6 +169,7 @@ namespace PnP.Framework
         /// </summary>
         /// <param name="clientId">The client id of the Azure AD application to use for authentication</param>
         /// <param name="certificate">A valid certificate</param>
+        /// <param name="tenantId">Tenant id or tenant url</param>
         /// <param name="redirectUrl">Optional redirect URL to use for authentication as set up in the Azure AD Application</param>
         /// <param name="azureEnvironment">The azure environment to use. Defaults to AzureEnvironment.Production</param>
         /// <param name="tokenCacheCallback">If present, after setting up the base flow for authentication this callback will be called register a custom tokencache. See https://aka.ms/msal-net-token-cache-serialization.</param>

--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -544,7 +544,7 @@ namespace PnP.Framework
         }
 
         /// <summary>
-        /// Get's the Azure ASC login end point for the given environment
+        /// Gets the Azure ASC login end point for the given environment
         /// </summary>
         /// <param name="environment">Environment to get the login information for</param>
         /// <returns>Azure ASC login endpoint</returns>
@@ -580,7 +580,7 @@ namespace PnP.Framework
         }
 
         /// <summary>
-        /// Get's the Azure ACS login end point prefix for the given environment
+        /// Gets the Azure ACS login end point prefix for the given environment
         /// </summary>
         /// <param name="environment">Environment to get the login information for</param>
         /// <returns>Azure ACS login endpoint prefix</returns>
@@ -764,7 +764,7 @@ namespace PnP.Framework
         }
 
         /// <summary>
-        /// Get's the Azure AD login end point for the given environment
+        /// Gets the Azure AD login end point for the given environment
         /// </summary>
         /// <param name="environment">Environment to get the login information for</param>
         /// <returns>Azure AD login endpoint</returns>

--- a/src/lib/PnP.Framework/Enums/TimeZone.cs
+++ b/src/lib/PnP.Framework/Enums/TimeZone.cs
@@ -219,7 +219,7 @@
         /// </summary>
         UTCPLUS0400_BAKU = 54,
         /// <summary>
-        /// Timezone for CENTAL AMERICA
+        /// Timezone for CENTRAL AMERICA
         /// </summary>
         UTCMINUS0600_CENTRAL_AMERICA = 55,
         /// <summary>

--- a/src/lib/PnP.Framework/Modernization/Cache/CacheManager.cs
+++ b/src/lib/PnP.Framework/Modernization/Cache/CacheManager.cs
@@ -61,7 +61,7 @@ namespace PnP.Framework.Modernization.Cache
         private static readonly string keyTermTransformatorCache = "keyTermTransformatorCache";
 
         /// <summary>
-        /// Get's the single cachemanager instance, singleton pattern
+        /// Gets the single cachemanager instance, singleton pattern
         /// </summary>
         public static CacheManager Instance
         {
@@ -91,7 +91,7 @@ namespace PnP.Framework.Modernization.Cache
 
         #region SharePoint Versions and AAD
         /// <summary>
-        /// Get's the cached SharePoint version for a given site
+        /// Gets the cached SharePoint version for a given site
         /// </summary>
         /// <param name="site">Site to get the SharePoint version for</param>
         /// <returns>Found SharePoint version or "Unknown" if not found in cache</returns>
@@ -122,7 +122,7 @@ namespace PnP.Framework.Modernization.Cache
         }
 
         /// <summary>
-        /// Get's the exact SharePoint version from cache
+        /// Gets the exact SharePoint version from cache
         /// </summary>
         /// <param name="site">Site to get the exact version for</param>
         /// <returns>Exact version from cache</returns>
@@ -207,7 +207,7 @@ namespace PnP.Framework.Modernization.Cache
 
         #region Client Side Components
         /// <summary>
-        /// Get's the clientside components from cache or if needed retrieves and caches them
+        /// Gets the clientside components from cache or if needed retrieves and caches them
         /// </summary>
         /// <param name="page">Page to grab the components for</param>
         /// <returns></returns>
@@ -266,7 +266,7 @@ namespace PnP.Framework.Modernization.Cache
 
         #region Base template and metadata
         /// <summary>
-        /// Get's the base template that will be used to filter out "OOB" fields
+        /// Gets the base template that will be used to filter out "OOB" fields
         /// </summary>
         /// <param name="web">web to operate against</param>
         /// <returns>Provisioning template of the base template of STS#0</returns>
@@ -1139,7 +1139,7 @@ namespace PnP.Framework.Modernization.Cache
 
         #region Content types
         /// <summary>
-        /// Get's the ID of a contenttype
+        /// Gets the ID of a contenttype
         /// </summary>
         /// <param name="pagesLibrary">Pages library holding the content type</param>
         /// <param name="contentTypeName">Name of the content type</param>

--- a/src/lib/PnP.Framework/Modernization/Cache/CacheManager.cs
+++ b/src/lib/PnP.Framework/Modernization/Cache/CacheManager.cs
@@ -310,6 +310,7 @@ namespace PnP.Framework.Modernization.Cache
         /// </summary>
         /// <param name="web">Web to operate against</param>
         /// <param name="sourceLibrary">Pages library instance</param>
+        /// <param name="pageType">Type of page</param>
         /// <returns>List of fields that need to be copied</returns>
         public List<FieldData> GetFieldsToCopy(Web web, List sourceLibrary, string pageType)
         {

--- a/src/lib/PnP.Framework/Modernization/Extensions/ListItemExtensions.cs
+++ b/src/lib/PnP.Framework/Modernization/Extensions/ListItemExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.SharePoint.Client
 
         #region Page usage information
         /// <summary>
-        /// Get's the page last modified date time
+        /// Gets the page last modified date time
         /// </summary>
         /// <param name="item">Page list item</param>
         /// <returns>DateTime of the last modification</returns>
@@ -115,7 +115,7 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Get's the page last modified by
+        /// Gets the page last modified by
         /// </summary>
         /// <param name="item">Page list item</param>
         /// <returns>Last modified by user/account</returns>
@@ -137,7 +137,7 @@ namespace Microsoft.SharePoint.Client
 
         #region Blog information
         /// <summary>
-        /// Get's the blog last published date time
+        /// Gets the blog last published date time
         /// </summary>
         /// <param name="item">Page list item</param>
         /// <returns>DateTime of the last modification</returns>
@@ -158,7 +158,7 @@ namespace Microsoft.SharePoint.Client
 
         #region Publishing Page information
         /// <summary>
-        /// Get's the page page layout file
+        /// Gets the page page layout file
         /// </summary>
         /// <param name="item">Page list item</param>
         /// <returns>Page layout file defined for this page</returns>
@@ -178,7 +178,7 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Get's the page page layout
+        /// Gets the page page layout
         /// </summary>
         /// <param name="item">Page list item</param>
         /// <returns>Page layout defined for this page</returns>
@@ -201,7 +201,7 @@ namespace Microsoft.SharePoint.Client
         }
 
         /// <summary>
-        /// Get's the page audience(s)
+        /// Gets the page audience(s)
         /// </summary>
         /// <param name="item">Page list item</param>
         /// <returns>Page layout defined for this page</returns>

--- a/src/lib/PnP.Framework/Modernization/Functions/BuiltIn.cs
+++ b/src/lib/PnP.Framework/Modernization/Functions/BuiltIn.cs
@@ -29,6 +29,7 @@ namespace PnP.Framework.Modernization.Functions
         /// <summary>
         /// Instantiates the base builtin function library
         /// </summary>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         /// <param name="pageClientContext">ClientContext object for the site holding the page being transformed</param>
         /// <param name="sourceClientContext">The ClientContext for the source </param>
         /// <param name="clientSidePage">Reference to the client side page</param>
@@ -1302,6 +1303,8 @@ namespace PnP.Framework.Modernization.Functions
         /// Rewrites summarylinks web part html to be compliant with the html supported by the client side text part
         /// </summary>
         /// <param name="text">Original wiki html content</param>
+        /// <param name="chromeType">Specifies the kind of border that surrounds the webpart, see PartChromeType for a complete list of possible values</param>
+        /// <param name="title">Webpart title</param>
         /// <returns>Html compliant with client side text part</returns>
         [FunctionDocumentation(Description = "Rewrites summarylinks web part html to be compliant with the html supported by the client side text part.",
                        Example = "{CleanedText} = TextCleanUpSummaryLinks({Text})")]

--- a/src/lib/PnP.Framework/Modernization/Functions/FunctionProcessor.cs
+++ b/src/lib/PnP.Framework/Modernization/Functions/FunctionProcessor.cs
@@ -28,6 +28,7 @@ namespace PnP.Framework.Modernization.Functions
         /// </summary>
         /// <param name="page">Client side page for which we're executing the functions/selectors as part of the mapping</param>
         /// <param name="pageTransformation">Webpart mapping information</param>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         public FunctionProcessor(ClientContext sourceClientContext, ClientSidePage page, PageTransformation pageTransformation, BaseTransformationInformation baseTransformationInformation, IList<ILogObserver> logObservers = null)
         {
             this.page = page;

--- a/src/lib/PnP.Framework/Modernization/Pages/BasePage.cs
+++ b/src/lib/PnP.Framework/Modernization/Pages/BasePage.cs
@@ -87,7 +87,7 @@ namespace PnP.Framework.Modernization.Pages
         #endregion
 
         /// <summary>
-        /// Get's the type of the web part
+        /// Gets the type of the web part
         /// </summary>
         /// <param name="webPartXml">Web part xml to analyze</param>
         /// <returns>Type of the web part as fully qualified name</returns>
@@ -602,7 +602,7 @@ namespace PnP.Framework.Modernization.Pages
 
 
         /// <summary>
-        /// Get's the type of the web part by detecting if from the available properties
+        /// Gets the type of the web part by detecting if from the available properties
         /// </summary>
         /// <param name="properties">Web part properties to analyze</param>
         /// <returns>Type of the web part as fully qualified name</returns>

--- a/src/lib/PnP.Framework/Modernization/Pages/BasePage.cs
+++ b/src/lib/PnP.Framework/Modernization/Pages/BasePage.cs
@@ -602,9 +602,10 @@ namespace PnP.Framework.Modernization.Pages
 
 
         /// <summary>
-        /// Gets the type of the web part by detecting if from the available properties
+        /// Gets the type of the web part by detecting it from the available properties
         /// </summary>
         /// <param name="properties">Web part properties to analyze</param>
+        /// <param name="isLegacy">If true tries additional webpart types used in legacy versions</param>
         /// <returns>Type of the web part as fully qualified name</returns>
         public string GetTypeFromProperties(Dictionary<string, object> properties, bool isLegacy = false)
         {

--- a/src/lib/PnP.Framework/Modernization/Pages/PublishingPage.cs
+++ b/src/lib/PnP.Framework/Modernization/Pages/PublishingPage.cs
@@ -36,6 +36,7 @@ namespace PnP.Framework.Modernization.Pages
         /// </summary>
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageTransformation">Page transformation information</param>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         public PublishingPage(ListItem page, PageTransformation pageTransformation, BaseTransformationInformation baseTransformationInformation, IList<ILogObserver> logObservers = null) : base(page, null, pageTransformation, logObservers)
         {
             // no PublishingPageTransformation specified, fall back to default
@@ -49,6 +50,7 @@ namespace PnP.Framework.Modernization.Pages
         /// </summary>
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageTransformation">Page transformation information</param>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         public PublishingPage(ListItem page, PageTransformation pageTransformation, PublishingPageTransformation publishingPageTransformation, BaseTransformationInformation baseTransformationInformation, ClientContext targetContext = null, IList<ILogObserver> logObservers = null) : base(page, null, pageTransformation, logObservers)
         {
             this.publishingPageTransformation = publishingPageTransformation;

--- a/src/lib/PnP.Framework/Modernization/Pages/PublishingPageOnPremises.cs
+++ b/src/lib/PnP.Framework/Modernization/Pages/PublishingPageOnPremises.cs
@@ -17,13 +17,14 @@ namespace PnP.Framework.Modernization.Pages
     /// </summary>
     public class PublishingPageOnPremises : PublishingPage
     {
-        
+
         #region Construction
         /// <summary>
         /// Instantiates a publishing page object
         /// </summary>
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageTransformation">Page transformation information</param>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         public PublishingPageOnPremises(ListItem page, PageTransformation pageTransformation, BaseTransformationInformation baseTransformationInformation, IList<ILogObserver> logObservers = null) : base(page, pageTransformation, baseTransformationInformation, logObservers)
         {
            
@@ -34,6 +35,7 @@ namespace PnP.Framework.Modernization.Pages
         /// </summary>
         /// <param name="page">ListItem holding the page to analyze</param>
         /// <param name="pageTransformation">Page transformation information</param>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         public PublishingPageOnPremises(ListItem page, PageTransformation pageTransformation, PublishingPageTransformation publishingPageTransformation, BaseTransformationInformation baseTransformationInformation, ClientContext targetContext = null, IList<ILogObserver> logObservers = null) : base(page, pageTransformation, publishingPageTransformation,  baseTransformationInformation, targetContext, logObservers)
         {
 

--- a/src/lib/PnP.Framework/Modernization/Publishing/PublishingBuiltIn.cs
+++ b/src/lib/PnP.Framework/Modernization/Publishing/PublishingBuiltIn.cs
@@ -25,6 +25,7 @@ namespace PnP.Framework.Modernization.Publishing
         /// <summary>
         /// Instantiates the base builtin function library
         /// </summary>
+        /// <param name="baseTransformationInformation">Page transformation information</param>
         /// <param name="sourceClientContext">The ClientContext for the source </param>
         public PublishingBuiltIn(BaseTransformationInformation baseTransformationInformation, ClientContext sourceClientContext, ClientContext targetClientContext, IList<ILogObserver> logObservers = null) : base(sourceClientContext)
         {

--- a/src/lib/PnP.Framework/Modernization/Telemetry/Observers/ConsoleObserver.cs
+++ b/src/lib/PnP.Framework/Modernization/Telemetry/Observers/ConsoleObserver.cs
@@ -129,9 +129,10 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         }
 
         /// <summary>
-        /// Cental method to output to console
+        /// Central method to output to console
         /// </summary>
         /// <param name="message"></param>
+        /// <param name="color">Foreground console color</param>
         public void Write(string message, ConsoleColor color = ConsoleColor.White)
         {
             message = message.Replace(LogStrings.KeyValueSeperatorToken, "=");

--- a/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownObserver.cs
+++ b/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownObserver.cs
@@ -30,6 +30,7 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         /// <param name="fileName">Name used to construct the log file name</param>
         /// <param name="folder">Folder that will hold the log file</param>
         /// <param name="includeDebugEntries">Include Debug Log Entries</param>
+        /// <param name="includeVerbose">Include verbose details</param>
         public MarkdownObserver(string fileName = "", string folder = "", bool includeDebugEntries = false, bool includeVerbose = false)
         {
             _includeDebugEntries = includeDebugEntries;

--- a/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownToSharePoint.cs
+++ b/src/lib/PnP.Framework/Modernization/Telemetry/Observers/MarkdownToSharePoint.cs
@@ -22,7 +22,10 @@ namespace PnP.Framework.Modernization.Telemetry.Observers
         /// Constructor to save a markdown report to SharePoint Modern Site Assets library
         /// </summary>
         /// <param name="context"></param>
-        /// <param name="folderName"></param>
+        /// <param name="folderName">Folder that will hold the log file</param>
+        /// <param name="fileName">Name used to construct the log file name</param>
+        /// <param name="includeDebugEntries">Include Debug Log Entries</param>
+        /// <param name="includeVerbose">Include verbose details</param>
         public MarkdownToSharePointObserver(ClientContext context, string folderName = "Transformation-Reports", string fileName = "", bool includeDebugEntries = false, bool includeVerbose = false) : base(fileName, null, includeDebugEntries, includeVerbose)
         {
             _clientContext = context;

--- a/src/lib/PnP.Framework/Modernization/Transform/AssetTransfer.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/AssetTransfer.cs
@@ -223,6 +223,7 @@ namespace PnP.Framework.Modernization.Transform
         /// </summary>
         /// <param name="sourceFileUrl"></param>
         /// <param name="targetLocationUrl"></param>
+        /// <param name="fileChunkSizeInMB">Size of chunks in MB in which the file will be split to be copied</param>
         /// <remarks>
         ///     Based on the documentation: https://docs.microsoft.com/en-us/sharepoint/dev/solution-guidance/upload-large-files-sample-app-for-sharepoint
         /// </remarks>

--- a/src/lib/PnP.Framework/Modernization/Transform/BaseTransform.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/BaseTransform.cs
@@ -90,6 +90,10 @@ namespace PnP.Framework.Modernization.Transform
         /// Notifies the observers of error messages
         /// </summary>
         /// <param name="message">The message.</param>
+        /// <param name="heading">The logical grouping for the messages based on the stage of transformation</param>
+        /// <param name="exception">Exception object</param>
+        /// <param name="ignoreException">For those areas where we swallow errors or they are non-critical to report</param>
+        /// <param name="isCriticalException">Marks this error as a critical exception that prevents transformation</param>
         public void LogError(string message, string heading = "", Exception exception = null, bool ignoreException = false, bool isCriticalException = false)
         {
             StackTrace stackTrace = new StackTrace();
@@ -110,6 +114,8 @@ namespace PnP.Framework.Modernization.Transform
         /// Notifies the observers of info messages
         /// </summary>
         /// <param name="message">The message.</param>
+        /// <param name="heading">The logical grouping for the messages based on the stage of transformation</param>
+        /// <param name="significance">Extra significance of the entry for the logs</param>
         public void LogInfo(string message, string heading = "", LogEntrySignificance significance = LogEntrySignificance.None)
         {
             StackTrace stackTrace = new StackTrace();
@@ -122,6 +128,7 @@ namespace PnP.Framework.Modernization.Transform
         /// Notifies the observers of warning messages
         /// </summary>
         /// <param name="message">The message.</param>
+        /// <param name="heading">The logical grouping for the messages based on the stage of transformation</param>
         public void LogWarning(string message, string heading = "")
         {
             StackTrace stackTrace = new StackTrace();
@@ -134,6 +141,7 @@ namespace PnP.Framework.Modernization.Transform
         /// Notifies the observers of debug messages
         /// </summary>
         /// <param name="message">The message.</param>
+        /// <param name="heading">The logical grouping for the messages based on the stage of transformation</param>
         public void LogDebug(string message, string heading = "")
         {
             StackTrace stackTrace = new StackTrace();

--- a/src/lib/PnP.Framework/Modernization/Transform/TermTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/TermTransformator.cs
@@ -377,8 +377,9 @@ namespace PnP.Framework.Modernization.Transform
         /// <summary>
         /// Extracts the term set id from the xml schema
         /// </summary>
-        /// <param name="xmlfieldSchema"></param>
-        /// <returns></returns>
+        /// <param name="xmlfieldSchema">XML Schema</param>
+        /// <param name="findSspId">If true the SspId will be returned, otherwise the TermSetId will be</param>
+        /// <returns>TermSetId or SspId depending on <paramref name="findSspId"/> value</returns>
         public static string ExtractTermSetIdOrSspIdFromXmlSchema(string xmlfieldSchema, bool findSspId = false)
         {
             //Credit: https://sharepointfieldnotes.blogspot.com/2011/08/sharepoint-2010-code-tips-setting.html

--- a/src/lib/PnP.Framework/Modernization/Transform/WikiHtmlTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/WikiHtmlTransformator.cs
@@ -58,6 +58,9 @@ namespace PnP.Framework.Modernization.Transform
         /// with image and/or video parts. Later on these web parts will be transformed to client side web parts
         /// </summary>
         /// <param name="wikiPageWebParts">List of web parts on the page</param>
+        /// <param name="handleWikiImagesAndVideos">If true images and videos embedded in wiki text will be transformed to actual image/video web parts,
+        /// else they'll get a placeholder and will be added as separate web parts at the end of the page</param>
+        /// <param name="addTableListImageAsImageWebPart">When an image lives inside a table (or list) then also add it as a separate image web part</param>
         /// <returns>Updated list of web parts</returns>
         public List<WebPartEntity> TransformPlusSplit(List<WebPartEntity> wikiPageWebParts, bool handleWikiImagesAndVideos, bool addTableListImageAsImageWebPart)
         {

--- a/src/lib/PnP.Framework/Pages/CanvasColumn.cs
+++ b/src/lib/PnP.Framework/Pages/CanvasColumn.cs
@@ -183,7 +183,7 @@ namespace PnP.Framework.Pages
                 controlWrittenToSection = true;
             }
 
-            // if a section does not contain a control we still need to render it, otherwise it get's "lost"
+            // if a section does not contain a control we still need to render it, otherwise it gets "lost"
             if (!controlWrittenToSection)
             {
                 // Obtain the json data

--- a/src/lib/PnP.Framework/Utilities/PnPCoreUtilities.cs
+++ b/src/lib/PnP.Framework/Utilities/PnPCoreUtilities.cs
@@ -11,7 +11,7 @@ namespace PnP.Framework.Utilities
     public static class PnPCoreUtilities
     {
         /// <summary>
-        /// Get's a tag that identifies the PnP Core library
+        /// Gets a tag that identifies the PnP Core library
         /// </summary>
         /// <returns>PnP Core library identification tag</returns>
         public static string PnPCoreVersionTag
@@ -32,7 +32,7 @@ namespace PnP.Framework.Utilities
             true);
 
         /// <summary>
-        /// Get's a tag that identifies the PnP Core library for UserAgent string
+        /// Gets a tag that identifies the PnP Core library for UserAgent string
         /// </summary>
         /// <returns>PnP Core library identification user-agent</returns>
         public static string PnPCoreUserAgent


### PR DESCRIPTION
This PR add some missing XML comments and fixes some typos found while going through the comments.

As there are 2400 warnings, I started with [CS1573](https://docs.microsoft.com/en-us/dotnet/csharp/misc/cs1573) ones, so methods already with XML comments but with some parameters missing.

I tried to check how the same parameters/properties were commented in the existing code to keep them similar and give a better user experience, i.e. contructor parameter and public property having the same comment.
In some cases I checked how the methods are used or ```git blame``` to get a better understanding of what each parameter does.


I might keep pushing new commits to this PR but feel free to merge it whenever you want 😃 