### PR TITLE
Feature: Added support to extract all teams

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -137,11 +137,29 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        private static string[] GetAllIdsForAllGroupsWithTeams(string accessToken)
+        private static string[] GetAllIdsForAllGroupsWithTeams(string accessToken, List<string> groupIdCollection, string nextPageUrl)
         {
-            var groupids = HttpHelper.MakeGetRequestForString($"{GraphHelper.MicrosoftGraphBaseURI}beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')&$select=Id", accessToken);
-            var value = JObject.Parse(groupids).Value<JArray>("value");
-            return value.Select(t => t.Value<string>("id")).ToArray();
+            if (groupIdCollection == null) groupIdCollection = new List<string>();
+
+            string requestUrl = nextPageUrl ?? $"{GraphHelper.MicrosoftGraphBaseURI}beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')&$select=Id";
+
+            string groupIds = HttpHelper.MakeGetRequestForString(requestUrl, accessToken);
+
+            var value = JObject.Parse(groupIds).Value<JArray>("value");
+
+            string nextPageUrlValue = JObject.Parse(groupIds).Value<string>("@odata.nextLink");
+
+            if (groupIdCollection.Count() == 0)
+            {
+                groupIdCollection = value.Select(t => t.Value<string>("id")).ToList();
+            }
+            else
+            {
+                var nextPageData = value.Select(t => t.Value<string>("id")).ToList();
+                groupIdCollection.AddRange(nextPageData);
+            }
+
+            return !string.IsNullOrEmpty(nextPageUrlValue) ? GetAllIdsForAllGroupsWithTeams(accessToken, groupIdCollection, nextPageUrlValue) : groupIdCollection.ToArray();
         }
 
         /// <summary>
@@ -1436,7 +1454,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     {
                         // Retrieve all groups with teams
 
-                        var groupIds = GetAllIdsForAllGroupsWithTeams(accessToken);
+                        var groupIds = GetAllIdsForAllGroupsWithTeams(accessToken, null, string.Empty);
                         foreach (var groupId in groupIds)
                         {
                             Team team = ParseTeamJson(configuration, accessToken, groupId, scope);


### PR DESCRIPTION
Currently, we can only extract 100 teams, if there are more than 100 teams then it won't work. This PR adds support for extracting >100 teams via the provisioning engine.

Please let me know if I should port it back to PnP Sites core as well.