### PR TITLE
Replaced graph beta call with already existing private method with v1 graph call

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1009,7 +1009,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             else
             {
                 // Simply delete the tab
-                HttpHelper.MakeDeleteRequest($"{GraphHelper.MicrosoftGraphBaseURI}beta/teams/{teamId}/channels/{channelId}/tabs/{tabId}", accessToken);
+                RemoveTeamTab(tabId, channelId, teamId, accessToken);
             }
 
             return tabId;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Just replaces a graph beta call to remove a teams tab with a call to the already existing method that uses a v1 graph call