### PR TITLE
Added SiteAlias to Site Collection creation

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -260,6 +260,10 @@ namespace PnP.Framework.Sites
                     {
                         creationOptionsValues.Add($"SPSiteLanguage:{siteCollectionCreationInformation.Lcid}");
                     }
+                    if (!string.IsNullOrEmpty(siteCollectionCreationInformation.SiteAlias))
+                    {
+                        creationOptionsValues.Add($"SiteAlias:{siteCollectionCreationInformation.SiteAlias}");
+                    }
                     creationOptionsValues.Add($"HubSiteId:{siteCollectionCreationInformation.HubSiteId}");
                     optionalParams.Add("CreationOptions", creationOptionsValues);
 

--- a/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
@@ -264,6 +264,11 @@ namespace PnP.Framework.Sites
         /// </summary>
         public Enums.Office365Geography? PreferredDataLocation { get; set; }
 
+        /// <summary>
+        /// SiteAlias of the underlying Office 365 Group, i.e. the site part of the url: https://contoso.sharepoint.com/sites/&lt;SiteAlias&gt;
+        /// </summary>
+        public string SiteAlias { get; set; }
+
         public SiteCreationGroupInformation()
         {
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Adds the ability to specify the SiteAlias during team site collection creation, i.e. the site segment of the url, e.g. https://contoso.sharepoint.com/sites/ &lt;SiteAlias&gt;