### PR TITLE
Feature - replaced GetFileByServerRelativeUrl to GetFileByServerRelativePath method

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Connectors/SharePointConnector.cs
+++ b/src/lib/PnP.Framework/Provisioning/Connectors/SharePointConnector.cs
@@ -347,7 +347,7 @@ namespace PnP.Framework.Provisioning.Connectors
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
                 {
                     string fileServerRelativeUrl = GetFileServerRelativeUrl(cc, fileName, container);
-                    File file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
+                    File file = cc.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(fileServerRelativeUrl));
                     cc.Load(file);
                     cc.ExecuteQueryRetry();
 
@@ -430,7 +430,7 @@ namespace PnP.Framework.Provisioning.Connectors
                 using (ClientContext cc = GetClientContext().Clone(GetConnectionString()))
                 {
                     string fileServerRelativeUrl = GetFileServerRelativeUrl(cc, fileName, container);
-                    var file = cc.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
+                    var file = cc.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(fileServerRelativeUrl));
                     cc.Load(file);
                     cc.ExecuteQueryRetry();
                     if (file.Exists)

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -823,7 +823,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             if (clientSidePage.Properties != null && clientSidePage.Properties.Any())
             {
                 string pageFilePath = page.PageListItem[FileRefField].ToString();
-                var pageFile = web.GetFileByServerRelativeUrl(pageFilePath);
+                var pageFile = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(pageFilePath));
                 web.Context.Load(pageFile, p => p.Properties);
 
                 foreach (var pageProperty in clientSidePage.Properties)

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -795,12 +795,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             try
                             {
-                                var spFile = web.GetFileByServerRelativeUrl(ct.DocumentTemplateUrl);
-                                spFile.EnsureProperties(f => f.Level, f => f.ServerRelativeUrl, f => f.Name);
+                                var spFile = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(ct.DocumentTemplateUrl));
+                                spFile.EnsureProperties(f => f.Level, f => f.ServerRelativePath, f => f.Name);
 
                                 // If we got here it's a file, let's grab the file's path and name
                                 var baseUri = new Uri(web.Url);
-                                var fullUri = new Uri(baseUri, spFile.ServerRelativeUrl);
+                                var fullUri = new Uri(baseUri, spFile.ServerRelativePath.DecodedUrl);
                                 var folderPath = System.Web.HttpUtility.UrlDecode(fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/'));
                                 var fileName = System.Web.HttpUtility.UrlDecode(fullUri.Segments[fullUri.Segments.Count() - 1]);
 
@@ -913,13 +913,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             try
                             {
                                 string serverRelativeUrl = $"{web.ServerRelativeUrl}/{defaultDoc.FileSourcePath}";
-                                var spFile = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+                                var spFile = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
 
-                                spFile.EnsureProperties(f => f.Level, f => f.ServerRelativeUrl, f => f.Name);
+                                spFile.EnsureProperties(f => f.Level, f => f.ServerRelativePath, f => f.Name);
 
                                 // If we got here it's a file, let's grab the file's path and name
                                 var baseUri = new Uri(web.Url);
-                                var fullUri = new Uri(baseUri, spFile.ServerRelativeUrl);
+                                var fullUri = new Uri(baseUri, spFile.ServerRelativePath.DecodedUrl);
                                 var folderPath = System.Web.HttpUtility.UrlDecode(fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/'));
                                 var fileName = System.Web.HttpUtility.UrlDecode(fullUri.Segments[fullUri.Segments.Count() - 1]);
 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -950,7 +950,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         {
             try
             {
-                var file = context.Web.GetFileByServerRelativeUrl(fileServerRelativeUrl);
+                var file = context.Web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(fileServerRelativeUrl));
                 context.Load(file);
                 context.ExecuteQueryRetry();
                 if (file.Exists)

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectPageContents.cs
@@ -39,7 +39,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 }
                 var welcomePageUrl = UrlUtility.Combine(web.ServerRelativeUrl, homepageUrl);
 
-                var file = web.GetFileByServerRelativeUrl(welcomePageUrl);
+                var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(welcomePageUrl));
                 try
                 {
                     var listItem = file.EnsureProperty(f => f.ListItemAllFields);
@@ -53,7 +53,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             //var folderPath = fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/');
                             //var fileName = fullUri.Segments[fullUri.Segments.Count() - 1];
 
-                            var homeFile = web.GetFileByServerRelativeUrl(welcomePageUrl);
+                            var homeFile = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(welcomePageUrl));
 
                             var limitedWPManager = homeFile.GetLimitedWebPartManager(PersonalizationScope.Shared);
 
@@ -202,7 +202,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
             var webParts = web.GetWebParts(welcomePageUrl);
 
-            var file = web.GetFileByServerRelativeUrl(welcomePageUrl);
+            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(welcomePageUrl));
 
             file.EnsureProperty(f => f.Level);
 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectPages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectPages.cs
@@ -42,7 +42,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     Microsoft.SharePoint.Client.File file = null;
                     try
                     {
-                        file = web.GetFileByServerRelativeUrl(url);
+                        file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(url));
                         web.Context.Load(file);
                         web.Context.ExecuteQueryRetry();
                     }
@@ -179,7 +179,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         page.LocalizeWebParts(web, parser, scope);
                     }
 
-                    file = web.GetFileByServerRelativeUrl(url);
+                    file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(url));
                     file.EnsureProperty(f => f.ListItemAllFields);
 
                     if (page.Fields.Any())

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -153,7 +153,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                     try
                     {
-                        var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+                        var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
                         string fileName = string.Empty;
                         if (serverRelativeUrl.IndexOf("/") > -1)
                         {
@@ -169,7 +169,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         web.Context.ExecuteQueryRetry();
 
                         var baseUri = new Uri(web.Url);
-                        var fullUri = new Uri(baseUri, file.ServerRelativeUrl);
+                        var fullUri = new Uri(baseUri, file.ServerRelativePath.DecodedUrl);
                         var folderPath = HttpUtility.UrlDecode(fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/'));
 
                         // Configure the filename to use 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -209,7 +209,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                     try
                     {
-                        var file = web.GetFileByServerRelativeUrl(serverRelativeUrl);
+                        var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(serverRelativeUrl));
                         string fileName = string.Empty;
                         if (serverRelativeUrl.IndexOf("/") > -1)
                         {
@@ -225,7 +225,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         web.Context.ExecuteQueryRetry();
 
                         var baseUri = new Uri(web.Url);
-                        var fullUri = new Uri(baseUri, file.ServerRelativeUrl);
+                        var fullUri = new Uri(baseUri, file.ServerRelativePath.DecodedUrl);
                         var folderPath = HttpUtility.UrlDecode(fullUri.Segments.Take(fullUri.Segments.Count() - 1).ToArray().Aggregate((i, x) => i + x).TrimEnd('/'));
 
                         // Configure the filename to use 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -733,7 +733,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
 
                         try
                         {
-                            var file = web.GetFileByServerRelativeUrl(s);
+                            var file = web.GetFileByServerRelativePath(ResourcePath.FromDecodedUrl(s));
                             web.Context.Load(file, f => f.UniqueId);
                             web.Context.ExecuteQueryRetry();
                             fileGuids.Add(file.UniqueId);


### PR DESCRIPTION
Replaced the GetFileByServerRelativeUrl to GetFileByServerRelativePath methods in the provisioning engine to support special chars in file names