### PR TITLE
Fix ACS token generation

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -349,6 +349,10 @@ namespace PnP.Framework
                         }
                         break;
                     }
+                case ClientContextType.SharePointACSAppOnly:
+                    {
+                        return appOnlyAccessToken;
+                    }
             }
             if (authResult?.AccessToken != null)
             {

--- a/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
@@ -484,7 +484,7 @@ namespace Microsoft.SharePoint.Client
         {
             string accessToken = null;
 
-            if (PnPProvisioningContext.Current != null)
+            if (PnPProvisioningContext.Current?.AcquireTokenAsync != null)
             {
                 accessToken = PnPProvisioningContext.Current.AcquireToken(new Uri(clientContext.Url).Authority, null);
             }
@@ -493,14 +493,7 @@ namespace Microsoft.SharePoint.Client
                 if (clientContext.GetContextSettings()?.AuthenticationManager != null)
                 {
                     var contextSettings = clientContext.GetContextSettings();
-                    if (contextSettings.Type == ClientContextType.SharePointACSAppOnly)
-                    {
-
-                    }
-                    else
-                    {
-                        accessToken = contextSettings.AuthenticationManager.GetAccessTokenAsync(clientContext.Url).GetAwaiter().GetResult();
-                    }
+                    accessToken = contextSettings.AuthenticationManager.GetAccessTokenAsync(clientContext.Url).GetAwaiter().GetResult();
                 }
                 else
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -172,7 +172,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             {
                 if (neededSourceLanguage == 0)
                 {
-                    neededSourceLanguage = page.LCID;
+                    neededSourceLanguage = page.LCID > 0 ? page.LCID : template.RegionalSettings.LocaleId;
                 }
                 else
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
@@ -82,39 +82,6 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                     web.ExecutePostAsync("/_api/web/SetChromeOptions", System.Text.Json.JsonSerializer.Serialize(jsonRequest)).GetAwaiter().GetResult();
 
-
-                    //if (PnPProvisioningContext.Current != null)
-                    //{
-                    //    // Get an Access Token for the SetChromeOptions request
-                    //    var spoResourceUri = new Uri(web.Url).Authority;
-                    //    var accessToken = PnPProvisioningContext.Current.AcquireToken(spoResourceUri, null);
-
-                    //    if (accessToken != null)
-                    //    {
-                    //        // Prepare the JSON request for SetChromeOptions
-                    //        var jsonRequest = new
-                    //        {
-                    //            headerLayout = web.HeaderLayout,
-                    //            headerEmphasis = web.HeaderEmphasis,
-                    //            megaMenuEnabled = web.MegaMenuEnabled,
-                    //        };
-
-                    //        // Build the URL of the SetChromeOptions API
-                    //        var setChromeOptionsApiUrl = $"{web.Url}/_api/web/SetChromeOptions";
-
-                    //        // Make the POST request to the SetChromeOptions API
-                    //        // and fail in case of any exception
-                    //        HttpHelper.MakePostRequest(setChromeOptionsApiUrl,
-                    //            jsonRequest,
-                    //            "application/json",
-                    //            accessToken);
-                    //    }
-                    //}
-                    //else
-                    //{
-                    //    web.Update();
-                    //    web.Context.ExecuteQueryRetry();
-                    //}
                 }
             }
             return parser;


### PR DESCRIPTION
- Fix ACS access token generation  #34 
- Add null pointer check
- Fall back to template LCID for ClientSitePage if none is provided