### PR TITLE
fix reading certificate bytes

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -216,19 +216,14 @@ namespace PnP.Framework
             {
                 ConfidentialClientApplicationBuilder builder = null;
 
-                using (var certfile = System.IO.File.OpenRead(certificatePath))
+                using (var certificate = new X509Certificate2(
+                    certificatePath,
+                    certificatePassword,
+                    X509KeyStorageFlags.Exportable |
+                    X509KeyStorageFlags.MachineKeySet |
+                    X509KeyStorageFlags.PersistKeySet))
                 {
-                    var certificateBytes = new byte[certfile.Length];
-                    certfile.Read(certificateBytes, 0, (int)certfile.Length);
-                    using (var certificate = new X509Certificate2(
-                        certificateBytes,
-                        certificatePassword,
-                        X509KeyStorageFlags.Exportable |
-                        X509KeyStorageFlags.MachineKeySet |
-                        X509KeyStorageFlags.PersistKeySet))
-                    {
-                        builder = ConfidentialClientApplicationBuilder.Create(clientId).WithCertificate(certificate).WithAuthority($"{azureADEndPoint}/organizations/");
-                    }
+                    builder = ConfidentialClientApplicationBuilder.Create(clientId).WithCertificate(certificate).WithAuthority($"{azureADEndPoint}/organizations/");
                 }
                 if (!string.IsNullOrEmpty(redirectUrl))
                 {


### PR DESCRIPTION
Code should check the return value of `certfile.Read(certificateBytes, 0, (int)certfile.Length)` because it may read less than `certfile.Length` bytes. This patch delegates the work to X509Certificate2. A good alternative would be to use `System.IO.File.ReadAllBytes(certificatePath)`.

I also think that disposing the certificate here is not correct. Isn't the disposed certificate later used by ConfidentialClientApplication?