### PR TITLE
Parse tokens in the SearchCenterUrl

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -393,9 +393,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                     string searchCenterUrl = parser.ParseString(webSettings.SearchCenterUrl);
                     if (!string.IsNullOrEmpty(searchCenterUrl) &&
-                        web.GetWebSearchCenterUrl(true) != webSettings.SearchCenterUrl)
+                        web.GetWebSearchCenterUrl(true) != searchCenterUrl)
                     {
-                        web.SetWebSearchCenterUrl(webSettings.SearchCenterUrl);
+                        web.SetWebSearchCenterUrl(searchCenterUrl);
                     }
 
                     var masterUrl = parser.ParseString(webSettings.MasterPageUrl);


### PR DESCRIPTION
The parsing already happens, but the result isn't used. This PR seeks to fix that.