### PR TITLE
Fix a null reference exception in cases where ClientContextSettings are null.

### DIFF
--- a/src/lib/PnP.Framework/PnPCoreSdkAuthenticationProvider.cs
+++ b/src/lib/PnP.Framework/PnPCoreSdkAuthenticationProvider.cs
@@ -92,7 +92,7 @@ namespace PnP.Framework
             get
             {
                 var contextSettings = clientContext.GetContextSettings();
-                if (contextSettings.Type == Utilities.Context.ClientContextType.Cookie)
+                if (contextSettings != null && contextSettings.Type == Utilities.Context.ClientContextType.Cookie)
                 {
                     if (cookieContainer == null)
                     {


### PR DESCRIPTION
Fix a null reference exception in cases where ClientContextSettings are null. Fixes #70 