### PR TITLE
Keep the existing stack information on rethrowing the exception.

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -460,7 +460,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             CallWebHooks(template, tokenParser, ProvisioningTemplateWebhookKind.ExceptionOccurred,
                                 handler.InternalName, ex);
-                            throw ex;
+                            throw;
                         }
                         CallWebHooks(template, tokenParser,
                             ProvisioningTemplateWebhookKind.ObjectHandlerProvisioningCompleted,


### PR DESCRIPTION
Keep the existing stack information on rethrowing the exception. Makes more sense for debugging.