### PR TITLE
Added check for existing team before checking archived status

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -404,17 +404,26 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         private static string CreateOrUpdateTeamFromGroup(PnPMonitoredScope scope, Team team, TokenParser parser, string groupId, string accessToken)
         {
             bool isCurrentlyArchived = false;
-            try
-            {
-                // Check the archival status of the team
-                string archiveStatusReq = HttpHelper.MakeGetRequestForString(
-                    $"{GraphHelper.MicrosoftGraphBaseURI}v1.0/teams/{groupId}?$select=isArchived", accessToken: accessToken);
 
-                isCurrentlyArchived = JToken.Parse(archiveStatusReq).Value<bool>("isArchived");
-            }
-            catch (Exception ex)
+            // Check if a group with groupId exists and has a team enabled
+            var doesGroupWithTeamExistReq = HttpHelper.MakeGetRequestForString(
+                $"{GraphHelper.MicrosoftGraphBaseURI}beta/groups?$select=id&$filter=id eq '{groupId}' and resourceProvisioningOptions/Any(x:x eq 'Team')", accessToken);
+            var returnedIds = GraphHelper.GetIdsFromList(doesGroupWithTeamExistReq);
+
+            if (returnedIds.Length > 0)
             {
-                scope.LogError("Error checking archive status", ex.Message);
+                try
+                {
+                    // Check the archival status of the team
+                    string archiveStatusReq = HttpHelper.MakeGetRequestForString(
+                        $"{GraphHelper.MicrosoftGraphBaseURI}v1.0/teams/{groupId}?$select=isArchived", accessToken: accessToken);
+
+                    isCurrentlyArchived = JToken.Parse(archiveStatusReq).Value<bool>("isArchived");
+                }
+                catch (Exception ex)
+                {
+                    scope.LogError("Error checking archive status", ex.Message);
+                } 
             }
 
             // If the Team is currently archived


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Added check for existing team before checking archived status so that we don't get an error logged for every new site collection with team being provisioned. Since the check for isArchived will cast an exception if the group doesn't exist this would always be cast when provisioning a new site collection with a team using a tenant template and by first checking if the team exists the isArchived check can be skipped.