### PR TITLE
Added token parsing of team displayname in log message

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -430,7 +430,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 else
                 {
                     // Else, we will skip processing the team
-                    scope.LogWarning($"Team {team.DisplayName} is currently archived, so processing it will be skipped");
+                    scope.LogWarning($"Team {parser.ParseString(team.DisplayName)} is currently archived, so processing it will be skipped");
                     return null;
                 }
             }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Added token parsing of team displayname in log message which would otherwise cause an exception if the displayname contained a token.