### PR TITLE
fix wrong ReadOnly setting on ContentType LinkedFields 

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -295,8 +295,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         fieldRef.Required,
                         fieldRef.Hidden,
                         fieldRef.UpdateChildren,
-                        fieldRef.ShowInDisplayForm,
-                        fieldRef.ReadOnly);
+                        null,
+                        null);
                 }
             }
 
@@ -496,8 +496,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     fieldRef.Required,
                     fieldRef.Hidden,
                     fieldRef.UpdateChildren,
-                    fieldRef.ShowInDisplayForm,
-                    fieldRef.ReadOnly);
+                    null,
+                    null);
             }
 
             // Add new CTs


### PR DESCRIPTION
Allow bool Flags to be null for AddFieldToContentType and pass null for ReadOnly and ShowInDisplayForm if called from ObjectContentTypes as template schema does not support this 2 settings and we should use the settings from sitecolumn.