### PR TITLE
Allow use of tokens for TopicHeader and AlternativeText in Pages

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -402,8 +402,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             page.PageHeader.TextAlignment = (PnPCore.PageHeaderTitleAlignment)Enum.Parse(typeof(PnPCore.PageHeaderTitleAlignment), clientSidePage.Header.TextAlignment.ToString());
                             page.PageHeader.ShowTopicHeader = clientSidePage.Header.ShowTopicHeader;
                             page.PageHeader.ShowPublishDate = clientSidePage.Header.ShowPublishDate;
-                            page.PageHeader.TopicHeader = clientSidePage.Header.TopicHeader;
-                            page.PageHeader.AlternativeText = clientSidePage.Header.AlternativeText;
+                            page.PageHeader.TopicHeader = parser.ParseString(clientSidePage.Header.TopicHeader);
+                            page.PageHeader.AlternativeText = parser.ParseString(clientSidePage.Header.AlternativeText);
                             page.PageHeader.Authors = clientSidePage.Header.Authors;
                             page.PageHeader.AuthorByLine = clientSidePage.Header.AuthorByLine;
                             page.PageHeader.AuthorByLineId = clientSidePage.Header.AuthorByLineId;


### PR DESCRIPTION
Minor changes on ObjectHandler/ObjectClientSidePages.cs to allow use of tokens for the page properties TopicHeader and AlternativeText.

<pnp:ClientSidePage PromoteAsNewsArticle="false" PromoteAsTemplate="false" Overwrite="true" EnableComments="false" Title="{resource:ListingMixedCommunicationsTitle}" ContentTypeID="0x0101...." PageName="test.aspx">
          <pnp:Header Type="Custom" LayoutType="NoImage" ShowTopicHeader="true" ShowPublishDate="false" TextAlignment="Center" **TopicHeader="{resource:ListingTitle}" AlternativeText="{resource:ListingTestTitle}"** Authors="[]" AuthorByLine="[]" AuthorByLineId="-1" />
          <pnp:Sections>
            <pnp:Section Order="1" Type="ThreeColumn">
           ...