### PR TITLE
Fix bug when trying to add existing member or owner to a unified group.

### DIFF
--- a/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
@@ -299,8 +299,8 @@ namespace PnP.Framework.Graph
                     }
                     catch (Exception ex)
                     {
-                        if (ex.InnerException.Message.Contains("Request_BadRequest") &&
-                            ex.InnerException.Message.Contains("added object references already exist"))
+                        if (ex.Message.Contains("Request_BadRequest") &&
+                            ex.Message.Contains("added object references already exist"))
                         {
                             // Skip any already existing member
                         }
@@ -390,8 +390,8 @@ namespace PnP.Framework.Graph
                     }
                     catch (Exception ex)
                     {
-                        if (ex.InnerException.Message.Contains("Request_BadRequest") &&
-                            ex.InnerException.Message.Contains("added object references already exist"))
+                        if (ex.Message.Contains("Request_BadRequest") &&
+                            ex.Message.Contains("added object references already exist"))
                         {
                             // Skip any already existing owner
                         }


### PR DESCRIPTION
Hi,
I'm trying to update a unified group with an existing user or owner, the Graph request is giving an error...

```
POST https://graph.microsoft.com/v1.0/groups/5d08888a-d9e3-44e9-8371-46f4d774ed72/owners/$ref HTTP/1.1
Host: graph.microsoft.com
User-Agent: NONISV|SharePointPnP|PnPCore/1.1.0.0
...
{"@odata.id":"https://graph.microsoft.com/v1.0/directoryObjects/56bc8f87-b25e-463d-88ef-1a243acccebd"}


```
and the response...


```
HTTP/1.1 400 Bad Request
Cache-Control: private
Content-Type: application/json
...
{
  "error": {
    "code": "Request_BadRequest",
    "message": "One or more added object references already exist for the following modified properties: 'owners'.",
    "innerError": {
      "date": "2021-01-27T18:01:47",
      "request-id": "1064c860-10b6-4c37-827b-00196731c901",
      "client-request-id": "1064c860-10b6-4c37-827b-00196731c901"
    }
  }
}

```

The code is failing when checking the exception to ignore that case, it is checking InnerException, what it comes null instead of checking directly the property Message...

![image](https://user-images.githubusercontent.com/8925463/106034730-8aebb080-60d3-11eb-81c7-bfefd0de925b.png)

![image](https://user-images.githubusercontent.com/8925463/106035268-339a1000-60d4-11eb-8f05-c93bad55b763.png)

I've modified that function to fix that.
Thanks