### PR TITLE
Updating WebTemplateExtensionId value in payload dictionary.

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -145,7 +145,8 @@ namespace PnP.Framework.Sites
             payload.Add("HubSiteId", siteCollectionCreationInformation.HubSiteId);
             // As per https://github.com/SharePoint/sp-dev-docs/issues/4810 the WebTemplateExtensionId property
             // is what currently drives the application of a custom site design during the creation of a modern site.
-            payload.Add("WebTemplateExtensionId", siteCollectionCreationInformation.SiteDesignId);
+            // Updating WebTemplateExtensionId, it's already defined in the method GetRequestPayload
+            payload["WebTemplateExtensionId"] = siteCollectionCreationInformation.SiteDesignId;
 
             bool sensitivityLabelExists = !string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel);
             if (sensitivityLabelExists)


### PR DESCRIPTION
PR for fixing issue #142 
Instead of adding the key-value, It updates the value for key WebTemplateExtensionId in the payload dictionary.
![image](https://user-images.githubusercontent.com/8925463/106291391-da54ec80-624b-11eb-9ee1-ea1a7bc056f3.png)
