### PR TITLE
Fix some warnings

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Connectors/OpenXML/PnPPackage.cs
+++ b/src/lib/PnP.Framework/Provisioning/Connectors/OpenXML/PnPPackage.cs
@@ -371,7 +371,7 @@ namespace PnP.Framework.Provisioning.Connectors.OpenXML
         {
             if (value == null)
             {
-                value = new byte[] { };
+                value = Array.Empty<byte>();
             }
 
             using (Stream stream = part.GetStream(FileMode.OpenOrCreate))

--- a/src/lib/PnP.Framework/Provisioning/Connectors/OpenXML/PnPPackageFormatException.cs
+++ b/src/lib/PnP.Framework/Provisioning/Connectors/OpenXML/PnPPackageFormatException.cs
@@ -8,6 +8,14 @@ namespace PnP.Framework.Provisioning.Connectors.OpenXML
     public class PnPPackageFormatException : ApplicationException
     {
         /// <summary>
+        /// Constructor for PnPPackageFormatException class
+        /// </summary>
+        public PnPPackageFormatException()
+            : base()
+        {
+        }
+
+        /// <summary>
         /// Constructor for PnPPackageFormatException class with the specified error message.
         /// </summary>
         /// <param name="message">A string that describes the exception</param>

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -110,7 +110,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         // Set ReadOnly as the last thing because a ReadOnly content type cannot be updated
                         if (this._step == FieldAndListProvisioningStepHelper.Step.LookupFields && existingCT.ReadOnly == false && ct.ReadOnly == true)
                         {
-                            scope.LogPropertyUpdate("ReadOnly");
+                            scope.LogPropertyUpdate(nameof(existingCT.ReadOnly));
                             existingCT.ReadOnly = ct.ReadOnly;
 
                             existingCT.Update(false);
@@ -142,7 +142,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
             if (existingContentType.Hidden != templateContentType.Hidden)
             {
-                scope.LogPropertyUpdate("Hidden");
+                scope.LogPropertyUpdate(nameof(existingContentType.Hidden));
                 existingContentType.Hidden = templateContentType.Hidden;
                 isDirty = true;
             }
@@ -150,32 +150,32 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             // If change is ReadOnly = True, it will be set later
             if (existingContentType.ReadOnly == true && templateContentType.ReadOnly == false)
             {
-                scope.LogPropertyUpdate("ReadOnly");
+                scope.LogPropertyUpdate(nameof(existingContentType.ReadOnly));
                 existingContentType.ReadOnly = templateContentType.ReadOnly;
                 isDirty = true;
             }
             if (existingContentType.Sealed != templateContentType.Sealed)
             {
-                scope.LogPropertyUpdate("Sealed");
+                scope.LogPropertyUpdate(nameof(existingContentType.Sealed));
                 existingContentType.Sealed = templateContentType.Sealed;
                 isDirty = true;
             }
             if (templateContentType.Description != null && existingContentType.Description != parser.ParseString(templateContentType.Description))
             {
-                scope.LogPropertyUpdate("Description");
+                scope.LogPropertyUpdate(nameof(existingContentType.Description));
                 existingContentType.Description = parser.ParseString(templateContentType.Description);
                 isDirty = true;
             }
             if (templateContentType.DocumentTemplate != null && existingContentType.DocumentTemplate != parser.ParseString(templateContentType.DocumentTemplate))
             {
-                scope.LogPropertyUpdate("DocumentTemplate");
+                scope.LogPropertyUpdate(nameof(existingContentType.DocumentTemplate));
                 existingContentType.DocumentTemplate = parser.ParseString(templateContentType.DocumentTemplate);
                 isDirty = true;
             }
             if (existingContentType.Name != parser.ParseString(templateContentType.Name))
             {
                 var oldName = existingContentType.Name;
-                scope.LogPropertyUpdate("Name");
+                scope.LogPropertyUpdate(nameof(existingContentType.Name));
                 existingContentType.Name = parser.ParseString(templateContentType.Name);
                 isDirty = true;
                 // CT is being renamed, add an extra token to the tokenparser
@@ -184,7 +184,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             }
             if (templateContentType.Group != null && existingContentType.Group != parser.ParseString(templateContentType.Group))
             {
-                scope.LogPropertyUpdate("Group");
+                scope.LogPropertyUpdate(nameof(existingContentType.Group));
                 existingContentType.Group = parser.ParseString(templateContentType.Group);
                 isDirty = true;
             }
@@ -193,19 +193,19 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             {
                 if (templateContentType.DisplayFormUrl != null && existingContentType.DisplayFormUrl != parser.ParseString(templateContentType.DisplayFormUrl))
                 {
-                    scope.LogPropertyUpdate("DisplayFormUrl");
+                    scope.LogPropertyUpdate(nameof(existingContentType.DisplayFormUrl));
                     existingContentType.DisplayFormUrl = parser.ParseString(templateContentType.DisplayFormUrl);
                     isDirty = true;
                 }
                 if (templateContentType.EditFormUrl != null && existingContentType.EditFormUrl != parser.ParseString(templateContentType.EditFormUrl))
                 {
-                    scope.LogPropertyUpdate("EditFormUrl");
+                    scope.LogPropertyUpdate(nameof(existingContentType.EditFormUrl));
                     existingContentType.EditFormUrl = parser.ParseString(templateContentType.EditFormUrl);
                     isDirty = true;
                 }
                 if (templateContentType.NewFormUrl != null && existingContentType.NewFormUrl != parser.ParseString(templateContentType.NewFormUrl))
                 {
-                    scope.LogPropertyUpdate("NewFormUrl");
+                    scope.LogPropertyUpdate(nameof(existingContentType.NewFormUrl));
                     existingContentType.NewFormUrl = parser.ParseString(templateContentType.NewFormUrl);
                     isDirty = true;
                 }
@@ -316,13 +316,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ContentTypes_Field__0__exists_in_content_type, fieldId);
                     if (fieldLink.Required != fieldRef.Required)
                     {
-                        scope.LogPropertyUpdate("Required");
+                        scope.LogPropertyUpdate(nameof(fieldLink.Required));
                         fieldLink.Required = fieldRef.Required;
                         isDirty = true;
                     }
                     if (fieldLink.Hidden != fieldRef.Hidden)
                     {
-                        scope.LogPropertyUpdate("Hidden");
+                        scope.LogPropertyUpdate(nameof(fieldLink.Hidden));
                         fieldLink.Hidden = fieldRef.Hidden;
                         isDirty = true;
                     }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -173,7 +173,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             {
                 if (existingCustomAction.CommandUIExtension != parser.ParseString(customAction.CommandUIExtension.ToString()))
                 {
-                    scope.LogPropertyUpdate("CommandUIExtension");
+                    scope.LogPropertyUpdate(nameof(existingCustomAction.CommandUIExtension));
                     existingCustomAction.CommandUIExtension = parser.ParseString(customAction.CommandUIExtension.ToString());
                     isDirty = true;
                 }
@@ -183,7 +183,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 // Required to allow for a delta action to blank out the CommandUIExtension attribute
                 if (existingCustomAction.CommandUIExtension != null)
                 {
-                    scope.LogPropertyUpdate("CommandUIExtension");
+                    scope.LogPropertyUpdate(nameof(existingCustomAction.CommandUIExtension));
                     existingCustomAction.CommandUIExtension = null;
                     isDirty = true;
                 }
@@ -209,7 +209,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
             if (existingCustomAction.Description != customAction.Description)
             {
-                scope.LogPropertyUpdate("Description");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.Description));
                 existingCustomAction.Description = customAction.Description;
                 isDirty = true;
             }
@@ -224,55 +224,55 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
             if (existingCustomAction.Group != customAction.Group)
             {
-                scope.LogPropertyUpdate("Group");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.Group));
                 existingCustomAction.Group = customAction.Group;
                 isDirty = true;
             }
             if (existingCustomAction.ImageUrl != parser.ParseString(customAction.ImageUrl))
             {
-                scope.LogPropertyUpdate("ImageUrl");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.ImageUrl));
                 existingCustomAction.ImageUrl = parser.ParseString(customAction.ImageUrl);
                 isDirty = true;
             }
             if (existingCustomAction.Location != customAction.Location)
             {
-                scope.LogPropertyUpdate("Location");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.Location));
                 existingCustomAction.Location = customAction.Location;
                 isDirty = true;
             }
             if (existingCustomAction.RegistrationId != parser.ParseString(customAction.RegistrationId))
             {
-                scope.LogPropertyUpdate("RegistrationId");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.RegistrationId));
                 existingCustomAction.RegistrationId = parser.ParseString(customAction.RegistrationId);
                 isDirty = true;
             }
             if (existingCustomAction.RegistrationType != customAction.RegistrationType)
             {
-                scope.LogPropertyUpdate("RegistrationType");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.RegistrationType));
                 existingCustomAction.RegistrationType = customAction.RegistrationType;
                 isDirty = true;
             }
             if (existingCustomAction.ScriptBlock != parser.ParseString(customAction.ScriptBlock))
             {
-                scope.LogPropertyUpdate("ScriptBlock");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.ScriptBlock));
                 existingCustomAction.ScriptBlock = parser.ParseString(customAction.ScriptBlock);
                 isDirty = true;
             }
             if (existingCustomAction.ScriptSrc != parser.ParseString(customAction.ScriptSrc))
             {
-                scope.LogPropertyUpdate("ScriptSrc");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.ScriptSrc));
                 existingCustomAction.ScriptSrc = parser.ParseString(customAction.ScriptSrc);
                 isDirty = true;
             }
             if (existingCustomAction.Sequence != customAction.Sequence)
             {
-                scope.LogPropertyUpdate("Sequence");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.Sequence));
                 existingCustomAction.Sequence = customAction.Sequence;
                 isDirty = true;
             }
             if (existingCustomAction.Title != parser.ParseString(customAction.Title))
             {
-                scope.LogPropertyUpdate("Title");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.Title));
                 existingCustomAction.Title = parser.ParseString(customAction.Title);
                 isDirty = true;
             }
@@ -288,7 +288,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
             if (existingCustomAction.Url != parser.ParseString(customAction.Url))
             {
-                scope.LogPropertyUpdate("Url");
+                scope.LogPropertyUpdate(nameof(existingCustomAction.Url));
                 existingCustomAction.Url = parser.ParseString(customAction.Url);
                 isDirty = true;
             }

--- a/src/lib/PnP.Framework/Provisioning/Providers/Markdown/MarkdownPnPSchemaBaseWriter.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Markdown/MarkdownPnPSchemaBaseWriter.cs
@@ -29,7 +29,7 @@ namespace PnP.Framework.Provisioning.Providers.Markdown
         public MarkdownPnPSchemaBaseWriter(Stream referenceSchema)
         {
             this._referenceSchema = referenceSchema ??
-                throw new ArgumentNullException("referenceSchema");
+                throw new ArgumentNullException(nameof(referenceSchema));
         }
 
         public abstract string NamespacePrefix { get; }

--- a/src/lib/PnP.Framework/Utilities/OAuth/DateTimeUtil.cs
+++ b/src/lib/PnP.Framework/Utilities/OAuth/DateTimeUtil.cs
@@ -24,7 +24,7 @@
         {
             if (timeSpan < System.TimeSpan.Zero)
             {
-                throw new System.ArgumentException("TimeSpan must be greater than or equal to TimeSpan.Zero.", "timeSpan");
+                throw new System.ArgumentException("TimeSpan must be greater than or equal to TimeSpan.Zero.", nameof(timeSpan));
             }
             return DateTimeUtil.Add(time, timeSpan);
         }

--- a/src/lib/PnP.Framework/Utilities/Themes/Palettes/Shades.cs
+++ b/src/lib/PnP.Framework/Utilities/Themes/Palettes/Shades.cs
@@ -31,8 +31,8 @@ namespace PnP.Framework.Utilities.Themes.Palettes
         private static readonly float[] ColorShadeTable = new float[] { 0.1F, 0.24F, 0.44F }; // default strongen
 
         // If the given shade's luminance is below/above these values, we'll swap to using the White/Black tables above
-        private static readonly float LowLuminanceThreshold = 0.2F;
-        private static readonly float HighLuminanceThreshold = 0.8F;
+        private const float LowLuminanceThreshold = 0.2F;
+        private const float HighLuminanceThreshold = 0.8F;
 
         public static Boolean IsValidShade(Shade shade)
         {

--- a/src/lib/PnP.Framework/Utilities/UnitTests/Web/MockEntryResponseProvider.cs
+++ b/src/lib/PnP.Framework/Utilities/UnitTests/Web/MockEntryResponseProvider.cs
@@ -29,7 +29,7 @@ namespace PnP.Framework.Utilities.UnitTests.Web
                 .ToList();
 
             StringBuilder responseBuilder = new StringBuilder();
-            responseBuilder.Append("[");
+            responseBuilder.Append('[');
             responseBuilder.Append(JsonConvert.SerializeObject(ResponseHeader));
             CSOMRequest request = GetRequest(body);
             List<ActionObjectPath<T>> actionsInRequest = GetActionObjectPathsFromRequest<T>(request);
@@ -40,7 +40,7 @@ namespace PnP.Framework.Utilities.UnitTests.Web
                 responseBuilder.Append($",{id}, {action.GetResponse(CurrentUrlResponses, request)}");
             }
 
-            responseBuilder.Append("]");
+            responseBuilder.Append(']');
             return responseBuilder.ToString();
         }
 


### PR DESCRIPTION
- CA1032: Implement standard exception constructors
- CA1507: Use nameof in place of string
- CA1834: Use StringBuilder.Append(char) for single character string
- CA1802: Use Literals Where Appropriate
- CA1825: Avoid zero-length array allocations