### PR TITLE
fix because Modern List Creation creates CTType with 0x01[Parent1][Parent2] but Parent1 does not exist

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1589,6 +1589,11 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 {
                     ContentTypeId existingContentTypeId = list.ContentTypes.BestMatch(ctb.ContentTypeId);
                     bool contentTypeAlreadyExistsInList = existingContentTypeId != null && existingContentTypeId.GetParentIdValue().Equals(ctb.ContentTypeId, StringComparison.OrdinalIgnoreCase);
+                    if (!contentTypeAlreadyExistsInList && BuiltInContentTypeId.Contains(ctb.ContentTypeId))
+                    {
+                        //fix because Modern List Creation creates CTType with 0x01[Parent1][Parent2] but Parent1 does not exist so it's not resolved above and we try to create the builtin CT 0x01 found by export and fail to create
+                        contentTypeAlreadyExistsInList = existingContentTypeId != null && existingContentTypeId.GetParentIdValue().StartsWith($"{ctb.ContentTypeId}", StringComparison.OrdinalIgnoreCase);
+                    }
                     if (ctb.Remove)
                     {
                         if (contentTypeAlreadyExistsInList)


### PR DESCRIPTION
fix because Modern List Creation (Lists-Dialog) creates CTType with 0x01[Parent1][Parent2] but Parent1 does not exist so it's not resolved above and we try to create the builtin CT 0x01 found by export and fail to create