### PR TITLE
Fix For SiteFooter Template Extraction

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -229,7 +229,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             fileName = serverRelativeUrl;
                         }
-                        web.Context.Load(file);
+                        web.Context.Load(file, f => f.ServerRelativePath);
                         web.Context.ExecuteQueryRetry();
                         ClientResult<Stream> stream = file.OpenBinaryStream();
                         web.Context.ExecuteQueryRetry();


### PR DESCRIPTION
ServerRelativePath was not being initialized on footer logo file.

> Microsoft.SharePoint.Client.PropertyOrFieldNotInitializedException: The property or field 'ServerRelativePath' has not been initialized. It has not been requested or the request has not been executed. It may need to be explicitly requested.
   at Microsoft.SharePoint.Client.ClientObject.CheckUninitializedProperty(String propName)
   at Microsoft.SharePoint.Client.File.get_ServerRelativePath()
   at PnP.Framework.Provisioning.ObjectHandlers.ObjectSiteFooterSettings.PersistFile(Web web, ProvisioningTemplateCreationInformation creationInfo, PnPMonitoredScope scope, String serverRelativeUrl)
   at PnP.Framework.Provisioning.ObjectHandlers.ObjectSiteFooterSettings.ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
   at PnP.Framework.Provisioning.ObjectHandlers.SiteToTemplateConversion.GetRemoteTemplate(Web web, ProvisioningTemplateCreationInformation creationInfo)
   at Microsoft.SharePoint.Client.WebExtensions.GetProvisioningTemplate(Web web, ProvisioningTemplateCreationInformation creationInfo)