### PR TITLE
Added additional Graph User properties

### DIFF
--- a/src/lib/PnP.Framework/Entities/UnifiedGroupUser.cs
+++ b/src/lib/PnP.Framework/Entities/UnifiedGroupUser.cs
@@ -3,18 +3,49 @@
 namespace PnP.Framework.Entities
 {
     /// <summary>
-    /// Defines a Unified Group user
+    /// Defines a Unified\Microsoft 365 Group user
     /// </summary>
     public class UnifiedGroupUser
     {
         /// <summary>
-        /// Unified group user's user principal name
+        /// Group user's unique identifier
+        /// </summary>
+        public string Id { get; set; }        
+        /// <summary>
+        /// Group user's user principal name
         /// </summary>
         public string UserPrincipalName { get; set; }
         /// <summary>
-        /// Unified group user's display name
+        /// Group user's display name
         /// </summary>
         public string DisplayName { get; set; }
-
+        /// <summary>
+        /// Group user's given name
+        /// </summary>
+        public string GivenName { get; set; }
+        /// <summary>
+        /// Group user's surname
+        /// </summary>
+        public string Surname { get; set; }
+        /// <summary>
+        /// Group user's e-mail address
+        /// </summary>
+        public string Email { get; set; }
+        /// <summary>
+        /// Group user's mobile phone number
+        /// </summary>
+        public string MobilePhone { get; set; }        
+        /// <summary>
+        /// Group user's preferred language in ISO 639-1 standard notation
+        /// </summary>
+        public string PreferredLanguage { get; set; }
+        /// <summary>
+        /// Group user's job title
+        /// </summary>
+        public string JobTitle { get; set; }
+        /// <summary>
+        /// Group user's business phone numbers
+        /// </summary>
+        public string[] BusinessPhones { get; set; }        
     }
 }

--- a/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
@@ -1119,8 +1119,16 @@ namespace PnP.Framework.Graph
                         {
                             UnifiedGroupUser groupUser = new UnifiedGroupUser
                             {
+                                Id = usr.Id,
                                 UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty,
-                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty
+                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty,
+                                GivenName = usr.GivenName != null ? usr.GivenName : string.Empty,
+                                Surname = usr.Surname != null ? usr.Surname : string.Empty,
+                                Email = usr.Mail != null ? usr.Mail : string.Empty,
+                                MobilePhone = usr.MobilePhone != null ? usr.DisplayName : string.Empty,
+                                PreferredLanguage = usr.PreferredLanguage != null ? usr.PreferredLanguage : string.Empty,
+                                JobTitle = usr.JobTitle != null ? usr.DisplayName : string.Empty,
+                                BusinessPhones = usr.BusinessPhones != null ? usr.BusinessPhones.ToArray() : null
                             };
                             unifiedGroupUsers.Add(groupUser);
                         }
@@ -1193,8 +1201,16 @@ namespace PnP.Framework.Graph
                         {
                             UnifiedGroupUser groupUser = new UnifiedGroupUser
                             {
+                                Id = usr.Id,
                                 UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty,
-                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty
+                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty,
+                                GivenName = usr.GivenName != null ? usr.GivenName : string.Empty,
+                                Surname = usr.Surname != null ? usr.Surname : string.Empty,
+                                Email = usr.Mail != null ? usr.Mail : string.Empty,
+                                MobilePhone = usr.MobilePhone != null ? usr.DisplayName : string.Empty,
+                                PreferredLanguage = usr.PreferredLanguage != null ? usr.PreferredLanguage : string.Empty,
+                                JobTitle = usr.JobTitle != null ? usr.DisplayName : string.Empty,
+                                BusinessPhones = usr.BusinessPhones != null ? usr.BusinessPhones.ToArray() : null                                
                             };
                             unifiedGroupUsers.Add(groupUser);
                         }
@@ -1502,8 +1518,16 @@ namespace PnP.Framework.Graph
                         {
                             UnifiedGroupUser groupUser = new UnifiedGroupUser
                             {
+                                Id = usr.Id,
                                 UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty,
-                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty
+                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty,
+                                GivenName = usr.GivenName != null ? usr.GivenName : string.Empty,
+                                Surname = usr.Surname != null ? usr.Surname : string.Empty,
+                                Email = usr.Mail != null ? usr.Mail : string.Empty,
+                                MobilePhone = usr.MobilePhone != null ? usr.DisplayName : string.Empty,
+                                PreferredLanguage = usr.PreferredLanguage != null ? usr.PreferredLanguage : string.Empty,
+                                JobTitle = usr.JobTitle != null ? usr.DisplayName : string.Empty,
+                                BusinessPhones = usr.BusinessPhones != null ? usr.BusinessPhones.ToArray() : null                                
                             };
                             unifiedGroupUsers.Add(groupUser);
                         }


### PR DESCRIPTION
We were already retrieving the full Graph user details anyway, but were not converting these over from the Graph `User` object to the PnP Framework `UnifiedGroupUser` equivalent. Updated the `UnifiedGroupUser` object to expose these properties we already have anyway. Doesn't require any additional calls to be made and the existing two properties remain unchanged, so this is backwards compatible.