### PR TITLE
Replace Thread.Sleep() with Task.Delay() in async methods

### DIFF
--- a/src/lib/PnP.Framework/ALM/AppManager.cs
+++ b/src/lib/PnP.Framework/ALM/AppManager.cs
@@ -948,7 +948,7 @@ namespace PnP.Framework.ALM
                     {
                         // try again
                         retryCount++;
-                        Thread.Sleep(waitTime * 1000); // wait 10 seconds
+                        await Task.Delay(waitTime * 1000); // wait 10 seconds
                     }
                 }
                 return returnValue;

--- a/src/lib/PnP.Framework/Extensions/FeatureExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/FeatureExtensions.cs
@@ -276,7 +276,7 @@ namespace Microsoft.SharePoint.Client
                         // wait and keep checking if the feature is active
                         while (retryAttempts > retryCount)
                         {
-                            Thread.Sleep(TimeSpan.FromSeconds(pollingIntervalSeconds));
+                            await Task.Delay(TimeSpan.FromSeconds(pollingIntervalSeconds));
                             if (await IsFeatureActiveInternal(features, featureID, true))
                             {
                                 retryCount = retryAttempts;

--- a/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
@@ -1783,7 +1783,7 @@ namespace PnP.Framework.Graph
                     {
                         // In case of exception wait for 30 secs
                         Log.Error(Constants.LOGGING_SOURCE, CoreResources.GraphExtensions_ErrorOccured, ex.Message);
-                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(30));
+                        await Task.Delay(TimeSpan.FromSeconds(30));
                     }
                 }
             }

--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -346,7 +346,7 @@ namespace PnP.Framework.Sites
                             {
                                 if (retryAttempt > 1)
                                 {
-                                    System.Threading.Thread.Sleep(retryAttempt * spOperationsRetryWait);
+                                    await Task.Delay(retryAttempt * spOperationsRetryWait);
                                 }
 
                                 try
@@ -408,7 +408,7 @@ namespace PnP.Framework.Sites
                     // If there is a delay, let's wait
                     if (delayAfterCreation > 0)
                     {
-                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(delayAfterCreation));
+                        await Task.Delay(TimeSpan.FromSeconds(delayAfterCreation));
                     }
                     else
                     {
@@ -613,7 +613,7 @@ namespace PnP.Framework.Sites
                                     {
                                         if (retryAttempt > 1)
                                         {
-                                            System.Threading.Thread.Sleep(retryAttempt * spOperationsRetryWait);
+                                            await Task.Delay(retryAttempt * spOperationsRetryWait);
                                         }
 
                                         try
@@ -703,7 +703,7 @@ namespace PnP.Framework.Sites
                     // If there is a delay, let's wait
                     if (delayAfterCreation > 0)
                     {
-                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(delayAfterCreation));
+                        await Task.Delay(TimeSpan.FromSeconds(delayAfterCreation));
                     }
                     else
                     {


### PR DESCRIPTION
Replace Thread.Sleep() with Task.Delay() in async methods as Thread.Sleep() suspends the current thread that, in case of async methods, could be a thread-pool thread, not allowing it to process other tasks.