### PR TITLE
Fix for updating team if a tab had Remove = True

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -988,7 +988,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 var tabId = existingTab == null ? CreateTeamTab(scope, tab, parser, teamId, channelId, accessToken) : UpdateTeamTab(tab, parser, teamId, channelId, existingTab["id"].ToString(), accessToken);
 
-                if (tabId == null) return false;
+                if (tabId == null && !tab.Remove) return false;
             }
             if (tabs.Any())
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for updating a team if a tab had Remove = True in the template. Without this fix the update aborted when it ran into a tab that had Remove = True.