### PR TITLE
fix if file is template in /libname/Forms folder and therefore has no ListItemId

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -143,7 +143,11 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             web.Context.Load(targetFile, p => p.ListItemAllFields.Id);
                             web.Context.ExecuteQueryRetry();
-                            parser.AddToken(new FileListItemIdToken(web, targetFile.ServerRelativePath.DecodedUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), targetFile.ListItemAllFields.Id));
+                            if (targetFile.ListItemAllFields.ServerObjectIsNull.HasValue
+                                && !targetFile.ListItemAllFields.ServerObjectIsNull.Value)
+                            {
+                                parser.AddToken(new FileListItemIdToken(web, targetFile.ServerRelativePath.DecodedUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), targetFile.ListItemAllFields.Id));
+                            }
                         }
                         catch (ServerException ex)
                         {


### PR DESCRIPTION
Upload of template files to the Forms folder of the Library did fail because of access to targetFile.ListItemAllFields.Id -
Added Check if have ListItemAllFields.
