### PR TITLE
Allow to specify the Sensitivity Label Id when creating a new site collection

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -113,10 +113,20 @@ namespace PnP.Framework.Sites
             }
             payload.Add("HubSiteId", siteCollectionCreationInformation.HubSiteId);
 
-            bool sensitivityLabelExists = !string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel);
-            if (sensitivityLabelExists)
+            Guid sensitivityLabelId = Guid.Empty;
+
+            // Use the sensitivity label id passed as input if specified or retrieve the id from the display name if specified
+            if (siteCollectionCreationInformation.SensitivityLabelId != Guid.Empty)
             {
-                Guid sensitivityLabelId = await GetSensitivityLabelId(clientContext, siteCollectionCreationInformation.SensitivityLabel);
+                sensitivityLabelId = siteCollectionCreationInformation.SensitivityLabelId;
+            }
+            else if (!string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel))
+            {
+                sensitivityLabelId = await GetSensitivityLabelId(clientContext, siteCollectionCreationInformation.SensitivityLabel);
+            }
+
+            if (sensitivityLabelId != Guid.Empty)
+            {                
                 payload.Add("SensitivityLabel", sensitivityLabelId);
                 payload["Classification"] = siteCollectionCreationInformation.SensitivityLabel;
             }
@@ -149,10 +159,20 @@ namespace PnP.Framework.Sites
             // Updating WebTemplateExtensionId, it's already defined in the method GetRequestPayload
             payload["WebTemplateExtensionId"] = siteCollectionCreationInformation.SiteDesignId;
 
-            bool sensitivityLabelExists = !string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel);
-            if (sensitivityLabelExists)
+            Guid sensitivityLabelId = Guid.Empty;
+
+            // Use the sensitivity label id passed as input if specified or retrieve the id from the display name if specified
+            if (siteCollectionCreationInformation.SensitivityLabelId != Guid.Empty)
             {
-                Guid sensitivityLabelId = await GetSensitivityLabelId(clientContext, siteCollectionCreationInformation.SensitivityLabel);
+                sensitivityLabelId = siteCollectionCreationInformation.SensitivityLabelId;
+            }
+            else if (!string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel))
+            {
+                sensitivityLabelId = await GetSensitivityLabelId(clientContext, siteCollectionCreationInformation.SensitivityLabel);
+            }
+
+            if (sensitivityLabelId != Guid.Empty)
+            {
                 payload.Add("SensitivityLabel", sensitivityLabelId);
                 payload["Classification"] = siteCollectionCreationInformation.SensitivityLabel;
             }
@@ -233,10 +253,14 @@ namespace PnP.Framework.Sites
 
             clientContext.Web.EnsureProperty(w => w.Url);
 
-            bool sensitivityLabelExists = !string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel);
+            Guid sensitivityLabelId = Guid.Empty;
 
-            var sensitivityLabelId = Guid.Empty;
-            if (sensitivityLabelExists)
+            // Use the sensitivity label id passed as input if specified or retrieve the id from the display name if specified
+            if (siteCollectionCreationInformation.SensitivityLabelId != Guid.Empty)
+            {
+                sensitivityLabelId = siteCollectionCreationInformation.SensitivityLabelId;
+            }
+            else if (!string.IsNullOrEmpty(siteCollectionCreationInformation.SensitivityLabel))
             {
                 sensitivityLabelId = await GetSensitivityLabelId(clientContext, siteCollectionCreationInformation.SensitivityLabel);
             }
@@ -259,7 +283,7 @@ namespace PnP.Framework.Sites
                 { "Description", siteCollectionCreationInformation.Description ?? "" }
             };
 
-            if (sensitivityLabelExists && sensitivityLabelId != Guid.Empty)
+            if (sensitivityLabelId != Guid.Empty)
             {
                 optionalParams.Add("Classification", siteCollectionCreationInformation.SensitivityLabel ?? "");
                 creationOptionsValues.Add($"SensitivityLabel:{sensitivityLabelId}");

--- a/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
@@ -28,6 +28,11 @@ namespace PnP.Framework.Sites
         public string SensitivityLabel { get; set; }
 
         /// <summary>
+        /// The Sensitivity label id to use. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
+        /// </summary>
+        public Guid SensitivityLabelId { get; set; }
+
+        /// <summary>
         /// Default constructor
         /// </summary>
         public CommunicationSiteCollectionCreationInformation() : this(string.Empty, string.Empty)
@@ -63,6 +68,10 @@ namespace PnP.Framework.Sites
         /// The Sensitivity label to use. For instance 'Top Secret'. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
         /// </summary>
         public string SensitivityLabel { get; set; }
+        /// <summary>
+        /// The Sensitivity label to use. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
+        /// </summary>
+        public Guid SensitivityLabelId { get; set; }
         /// <summary>
         /// Default constructor
         /// </summary>
@@ -270,6 +279,11 @@ namespace PnP.Framework.Sites
         /// The Sensitivity label to use. For instance 'Top Secret'. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
         /// </summary>
         public string SensitivityLabel { get; set; }
+
+        /// <summary>
+        /// The Sensitivity label to use. See https://www.youtube.com/watch?v=NxvUXBiPFcw for more information.
+        /// </summary>
+        public Guid SensitivityLabelId { get; set; }
 
         /// <summary>
         /// The geography in which to create the site collection. Only applicable to multi-geo enabled tenants.


### PR DESCRIPTION
Allow to specify the Sensitivity Label Id when creating a new site collection, in addition to the Display name already supported. If both Id and Display name are specified, no exception is thrown but the Id takes precedence.

This is needed in a real-world case in a provisioning solution using Azure Functions where the sensitivity label is passed from another system as guid.