### PR TITLE
Fix Site Design creation/update via provisioning engine - WebTemplate not being set

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/TenantHelper.cs
@@ -333,20 +333,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                             PreviewImageUrl = parsedPreviewImageUrl,
                             PreviewImageAltText = parsedPreviewImageAltText,
                             IsDefault = siteDesign.IsDefault,
+                            WebTemplate = ((int)siteDesign.WebTemplate).ToString()
                         };
-                        switch ((int)siteDesign.WebTemplate)
-                        {
-                            case 0:
-                                {
-                                    siteDesignCreationInfo.WebTemplate = "64";
-                                    break;
-                                }
-                            case 1:
-                                {
-                                    siteDesignCreationInfo.WebTemplate = "68";
-                                    break;
-                                }
-                        }
+
                         if (siteDesign.SiteScripts != null && siteDesign.SiteScripts.Any())
                         {
                             List<Guid> ids = new List<Guid>();
@@ -384,19 +373,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                             existingSiteDesign.PreviewImageUrl = parsedPreviewImageUrl;
                             existingSiteDesign.PreviewImageAltText = parsedPreviewImageAltText;
                             existingSiteDesign.IsDefault = siteDesign.IsDefault;
-                            switch ((int)siteDesign.WebTemplate)
-                            {
-                                case 0:
-                                    {
-                                        existingSiteDesign.WebTemplate = "64";
-                                        break;
-                                    }
-                                case 1:
-                                    {
-                                        existingSiteDesign.WebTemplate = "68";
-                                        break;
-                                    }
-                            }
+                            existingSiteDesign.WebTemplate = ((int)siteDesign.WebTemplate).ToString();
 
                             tenant.UpdateSiteDesign(existingSiteDesign);
                             tenant.Context.ExecuteQueryRetry();


### PR DESCRIPTION
When using the provisioning engine to create a site design, the WebTemplate property was not being set, and therefore was not showing up in the select a topic UI when creating a new site.

The reason for this was the WebTemplate property (which is a SiteDesignWebTemplate enum with the options TeamSite = 64 and CommunicationSite = 68) was expecting a 0 and 1 instead of 64 or 68 respectively.

This PR corrects this for both new site designs as well as updating existing (when the Overwrite property is true) site designs via the provisioning engine.