### PR TITLE
Fix: Implemented retry logic for getting and creating teams tabs

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1009,7 +1009,37 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         public static JToken GetExistingTeamChannelTabs(string teamId, string channelId, string accessToken)
         {
-            return JToken.Parse(HttpHelper.MakeGetRequestForString($"{GraphHelper.MicrosoftGraphBaseURI}v1.0/teams/{teamId}/channels/{channelId}/tabs?$expand=teamsApp", accessToken))["value"];
+            const int maxRetryCount = 60;
+            const int retryDelay = 1000;
+            var retryAttempt = 0;
+
+            JToken response = null;
+
+            do
+            {
+                try
+                {
+                    response = JToken.Parse(HttpHelper.MakeGetRequestForString($"{GraphHelper.MicrosoftGraphBaseURI}v1.0/teams/{teamId}/channels/{channelId}/tabs?$expand=teamsApp", accessToken))["value"];
+                }
+                catch (Exception ex)
+                {
+                    if (ex.InnerException != null && ex.InnerException.Message.Contains("No active channel found with channel id:"))
+                    {
+                        Thread.Sleep(retryDelay);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+
+                if (response == null)
+                {
+                    retryAttempt++;
+                }
+            } while (response == null && retryAttempt <= maxRetryCount);
+
+            return response;
         }
 
         private static string UpdateTeamTab(TeamTab tab, TokenParser parser, string teamId, string channelId, string tabId, string accessToken)
@@ -1179,18 +1209,34 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 { "teamsApp@odata.bind", "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/" + teamsAppId }
             };
 
-            var tabId = GraphHelper.CreateOrUpdateGraphObject(scope,
-                HttpMethodVerb.POST,
-                $"{GraphHelper.MicrosoftGraphBaseURI}v1.0/teams/{teamId}/channels/{channelId}/tabs",
-                JsonConvert.SerializeObject(tabToCreate),
-                HttpHelper.JsonContentType,
-                accessToken,
-                "NameAlreadyExists",
-                CoreResources.Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists,
-                "displayName",
-                displayname,
-                CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
-                false);
+            const int maxRetryCount = 60;
+            const int retryDelay = 1000;
+            var retryAttempt = 0;
+
+            string tabId;
+
+            do
+            {
+                if (retryAttempt > 1)
+                {
+                    Thread.Sleep(retryDelay);
+                }
+
+                tabId = GraphHelper.CreateOrUpdateGraphObject(scope,
+                    HttpMethodVerb.POST,
+                    $"{GraphHelper.MicrosoftGraphBaseURI}v1.0/teams/{teamId}/channels/{channelId}/tabs",
+                    JsonConvert.SerializeObject(tabToCreate),
+                    HttpHelper.JsonContentType,
+                    accessToken,
+                    "NameAlreadyExists",
+                    CoreResources.Provisioning_ObjectHandlers_Teams_Team_TabAlreadyExists,
+                    "displayName",
+                    displayname,
+                    CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
+                    false);
+
+                retryAttempt++;
+            } while (tabId == null && retryAttempt <= maxRetryCount);
 
             return tabId;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Implemented some retry logic for getting and creating teams tabs. Sometimes an exception is thrown when getting or creating teams tabs immediately after creating teams channels, especially when creating multiple private channels and under higher load so this fix checks for that and retries the operation.