### PR TITLE
Fix: Always create private channels with isFavoriteByDefault false

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -938,7 +938,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             {
                 channel.Description,
                 channel.DisplayName,
-                channel.IsFavoriteByDefault,
+                isFavoriteByDefault = channel.Private ? false : channel.IsFavoriteByDefault,
                 membershipType = channel.Private ? "private" : "standard",
                 members = (channel.Private && channelMembers != null) ? (from m in channelMembers
                                                                          select new


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix so that a teams private channels always are created with isFavoriteByDefault=false since a private channel cannot be created with isFavoriteByDefault=true. When trying to an error will be returned from Graph and the provisioning process is interrupted without any message on what went wrong.