### PR TITLE
Fix issue if SP Group has description with more then 512 char

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -322,7 +322,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         group = web.AddGroup(
                             parsedGroupTitle,
                             //If the description is more than 512 characters long a server exception will be thrown.
-                            PnPHttpUtility.ConvertSimpleHtmlToText(parsedGroupDescription, int.MaxValue),
+                            PnPHttpUtility.ConvertSimpleHtmlToText(parsedGroupDescription, 511),
                             parsedGroupTitle == parsedGroupOwner);
                         group.AllowMembersEditMembership = siteGroup.AllowMembersEditMembership;
                         group.AllowRequestToJoinLeave = siteGroup.AllowRequestToJoinLeave;
@@ -392,7 +392,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                 executeQuery = true;
                             }
 
-                            var plainTextDescription = PnPHttpUtility.ConvertSimpleHtmlToText(parsedGroupDescription, int.MaxValue);
+                            var plainTextDescription = PnPHttpUtility.ConvertSimpleHtmlToText(parsedGroupDescription, 511);
                             if (group.Description != plainTextDescription)
                             {
                                 //If the description is more than 512 characters long a server exception will be thrown.


### PR DESCRIPTION
As this Function already contains the logic we only need to change from int.MaxValue to 511 in order to have Description length limited. 
PnPHttpUtility.ConvertSimpleHtmlToText(parsedGroupDescription, int.MaxValue) 

For the group["notes"] field we can continue to use full size of description.
