### PR TITLE
[BUGFIX] Hanging request and big list issue with CreateDocumentSet

### DIFF
--- a/src/lib/PnP.Framework/Extensions/FileFolderExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/FileFolderExtensions.cs
@@ -237,7 +237,10 @@ namespace Microsoft.SharePoint.Client
             await folder.Context.ExecuteQueryAsync();
             var fullUri = new Uri(result.Value);
             var serverRelativeUrl = fullUri.AbsolutePath;
-            var documentSetFolder = folder.Folders.GetByUrl(serverRelativeUrl);
+
+            var ctx = folder.Context as ClientContext;
+            var resourcePath = ResourcePath.FromDecodedUrl(serverRelativeUrl);
+            var documentSetFolder = ctx.Web.GetFolderByServerRelativePath(resourcePath);
 
             return documentSetFolder;
         }


### PR DESCRIPTION
- Fixes a "hanging" request that wasn't executed before leaving the method
-Switches from `.Folders.GetByUrl` to `web.GetFolderByServerRelativePath` => interaction with .Folders triggers listview throttling while the other method does, on a big list

Fixes #287 , thanks @patrikhellgren !