### PR TITLE
Improve exception messages when acsTokenGenerator is null in AuthenticationManager

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -705,6 +705,8 @@ namespace PnP.Framework
                     }
                 case ClientContextType.SharePointACSAppOnly:
                     {
+                        if (acsTokenGenerator == null)
+                            throw new ArgumentException($"{nameof(GetAccessTokenAsync)}() called without an ACS token generator. Specify in {nameof(AuthenticationManager)} constructor the authentication parameters");
                         return acsTokenGenerator.GetToken(null);
                     }
                 case ClientContextType.AccessToken:
@@ -865,6 +867,9 @@ namespace PnP.Framework
 
                 case ClientContextType.SharePointACSAppOnly:
                     {
+                        if (this.acsTokenGenerator == null)
+                            throw new ArgumentException($"{nameof(GetContextAsync)}() called without an ACS token generator. Use {nameof(GetACSAppOnlyContext)}() or {nameof(GetAccessTokenContext)}() instead or specify in {nameof(AuthenticationManager)} constructor the authentication parameters");
+
                         var context = GetAccessTokenContext(siteUrl, (site) =>
                         {
                             return this.acsTokenGenerator.GetToken(new Uri(site));


### PR DESCRIPTION
This PR improves exception messages when acsTokenGenerator is null in AuthenticationManager. This can happen when the AuthenticationManager is created improperly, which can happen easily considering all the possible overloads and different methods, especially when trying to map the old PnP-Sites-Core code.

This PR fixes the following cases:
```c#
// Case 1
var context = new PnP.Framework.AuthenticationManager().GetContext("https://justatest.sharepoint.com");
context.ExecuteQuery();

// Case 2
var token = new PnP.Framework.AuthenticationManager().GetAccessToken("https://justatest.sharepoint.com");
```

With the previous code, this would have triggered a NullReferenceException:
![image](https://user-images.githubusercontent.com/1153754/116727704-319e6080-a9e5-11eb-8da2-8c5b31195fe6.png)

now it will show an error message that explains a bit more in detail what is wrong and what the user should do to fix the issue:
![image](https://user-images.githubusercontent.com/1153754/116727833-5db9e180-a9e5-11eb-9ea2-548a2a167731.png)

It's not that easy to provide a 100% working suggestion to the user as that changes depending on the scenario but it's a start.

Feel free to edit the exception message or let me know if I should apply any change.