### PR TITLE
Fix IEnumerable.Union() result being discarded in ContentByQuerySearchTransformator

### DIFF
--- a/src/lib/PnP.Framework/Modernization/Transform/ContentByQuerySearchTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/ContentByQuerySearchTransformator.cs
@@ -1291,7 +1291,7 @@ namespace PnP.Framework.Modernization.Transform
                     case "items matching a content type":
                     case "items related to a current user":
                         {
-                            cts.Union(MapToContentTypesFromContentType(contentTypeId));
+                            cts = MapToContentTypesFromContentType(contentTypeId);
                             break;
                         }
                     default:


### PR DESCRIPTION
This PR fixes a typo where the result of IEnumerable.Union() is discarded. The author probably assumed this LINQ method was going to modify the collection itself but it actually returns a new collection.

In this particular case the first collection is always empty, so it's enough to just assign the variable to the second collection.
```c#
List<ContentType> cts = new List<ContentType>();
```

Another way could be to assign the result of Union() to the variable `cts` .

Please note that I'm not familiar with how this part of the code is used or how to test it but it looks like a small change only.