### PR TITLE
Fix conversion between PnPCore enum values and PnP.Framework enums

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -114,12 +114,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                         var extractedHeader = new ClientSidePageHeader()
                         {
                             //Type = (ClientSidePageHeaderType)Enum.Parse(typeof(Pages.ClientSidePageHeaderType), pageToExtract.PageHeader.Type.ToString()),
-                            Type = (ClientSidePageHeaderType)Enum.Parse(typeof(PnPCore.PageHeaderType), (pageToExtract.PageHeader as PnPCore.PageHeader).Type.ToString()),
+                            Type = (ClientSidePageHeaderType)Enum.Parse(typeof(ClientSidePageHeaderType), (pageToExtract.PageHeader as PnPCore.PageHeader).Type.ToString()),
                             ServerRelativeImageUrl = TokenizeJsonControlData(web, pageToExtract.PageHeader.ImageServerRelativeUrl),
                             TranslateX = pageToExtract.PageHeader.TranslateX,
                             TranslateY = pageToExtract.PageHeader.TranslateY,
-                            LayoutType = (ClientSidePageHeaderLayoutType)Enum.Parse(typeof(PnPCore.PageHeaderLayoutType), pageToExtract.PageHeader.LayoutType.ToString()),
-                            TextAlignment = (ClientSidePageHeaderTextAlignment)Enum.Parse(typeof(PnPCore.PageHeaderTitleAlignment), pageToExtract.PageHeader.TextAlignment.ToString()),
+                            LayoutType = (ClientSidePageHeaderLayoutType)Enum.Parse(typeof(ClientSidePageHeaderLayoutType), pageToExtract.PageHeader.LayoutType.ToString()),
+                            TextAlignment = (ClientSidePageHeaderTextAlignment)Enum.Parse(typeof(ClientSidePageHeaderTextAlignment), pageToExtract.PageHeader.TextAlignment.ToString()),
                             ShowTopicHeader = pageToExtract.PageHeader.ShowTopicHeader,
                             ShowPublishDate = pageToExtract.PageHeader.ShowPublishDate,
                             TopicHeader = pageToExtract.PageHeader.TopicHeader,


### PR DESCRIPTION
This PR fixes a conversion between PnPCore enum values and PnP.Framework enums. The old code does a C-style cast from the PnPCore enum to the PnP.Framework one but the 2 enums have the possible values defined in different order:

PnPCore:
```c#
  //
  // Summary:
  //     Alignment of the title in a page header
  public enum PageHeaderTitleAlignment
  {
      //
      // Summary:
      //     Page title is centered
      Center,
      //
      // Summary:
      //     Page title is left aligned
      Left
  }
```

PnP.Framework:
```c#
  public enum ClientSidePageHeaderTextAlignment
  {
      /// <summary>
      /// Align Left
      /// </summary>
      Left,
      /// <summary>
      /// Align Center
      /// </summary>
      Center,
  }
```

This means PageHeaderTitleAlignment.Left with value 1 gets converted to ClientSidePageHeaderTextAlignment of value 1, so ClientSidePageHeaderTextAlignment.Center .

The current code already tries to convert from an enum to another through .ToString() but parses it back to PnPCore enum instead of PnP.Framework.

To compare the old and the new code:
- old: PnPCore enum -> ToString() -> parse into PnPCore enum -> c-style cast to PnPFramework
- new: PnPCore enum -> ToString() -> parse into PnPFramework enum -> c-style cast to PnPFramework
While at it I updated 2 other similar fields `Type` and `LayoutType` that never showed any issue because the enums are defined in the same order in both projects.

In addition to this it might be worth to consider having the 2 enums with the same order in both projects.

Fix #266