### PR TITLE
Fix tokenize url in new document template

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -232,6 +232,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     xml = Regex.Replace(xml, contentType.Id.StringValue, contentTypeReplacement, RegexOptions.IgnoreCase);
                 }
 
+                if(!string.IsNullOrWhiteSpace(NewDocumentTemplatesJson))
+                {
+                    web.EnsureProperties(w => w.ServerRelativeUrl);
+                    NewDocumentTemplatesJson=Regex.Replace(NewDocumentTemplatesJson,web.ServerRelativeUrl.TrimEnd('/'),"{site}", RegexOptions.IgnoreCase);
+                }
+
                 string tokenizedXML = TokenizeXml(xml, web);
                 if (!string.IsNullOrWhiteSpace(NewDocumentTemplatesJson))
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.SharePoint.Client;
 using Microsoft.SharePoint.Client.Taxonomy;
+using Newtonsoft.Json.Linq;
 using PnP.Framework.Provisioning.Model;
 using PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions;
 using System;
@@ -235,7 +236,29 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 if(!string.IsNullOrWhiteSpace(NewDocumentTemplatesJson))
                 {
                     web.EnsureProperties(w => w.ServerRelativeUrl);
-                    NewDocumentTemplatesJson=Regex.Replace(NewDocumentTemplatesJson,web.ServerRelativeUrl.TrimEnd('/'),"{site}", RegexOptions.IgnoreCase);
+                    try
+                    {
+                        var JObjNewDocTemplate = JArray.Parse(NewDocumentTemplatesJson);
+                        var fileUrls = JObjNewDocTemplate.SelectTokens("..url");
+                        foreach (var templateFile in fileUrls)
+                        {
+                            var templateObj = templateFile.Parent.Parent as JObject;
+                            string orgValue = (string)templateObj["url"];
+                            if (!string.IsNullOrWhiteSpace(orgValue))
+                            {
+                                if (web.ServerRelativeUrl == "/")
+                                {
+                                    templateObj["url"] = $"{{site}}/{orgValue.TrimStart('/')}";
+                                }
+                                else
+                                {
+                                    templateObj["url"] = Regex.Replace(orgValue, web.ServerRelativeUrl.TrimEnd('/'), "{site}", RegexOptions.IgnoreCase); ;
+                                }
+                            }
+                        }
+                        NewDocumentTemplatesJson = JObjNewDocTemplate.ToString(Newtonsoft.Json.Formatting.None);
+                    }
+                    catch { }
                 }
 
                 string tokenizedXML = TokenizeXml(xml, web);


### PR DESCRIPTION
make sure the url to the template document in NewDocumentTemplate-Json is tokenized in export.