### PR TITLE
Match JsonPropertyName values in ExtractConfiguration with https://aka.ms/sppnp-extract-configuration-schema

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Model/Configuration/ContentTypes/ExtractContentTypeConfiguration.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/Configuration/ContentTypes/ExtractContentTypeConfiguration.cs
@@ -5,10 +5,10 @@ namespace PnP.Framework.Provisioning.Model.Configuration.ContentTypes
 {
     public class ExtractContentTypeConfiguration
     {
-        [JsonPropertyName("Groups")]
+        [JsonPropertyName("groups")]
         public List<string> Groups { get; set; } = new List<string>();
 
-        [JsonPropertyName("IncludeFromSyndication")]
+        [JsonPropertyName("excludeFromSyndication")]
         public bool ExcludeFromSyndication { get; set; }
     }
 }

--- a/src/lib/PnP.Framework/Provisioning/Model/Configuration/MultiLanguage/ExtractMultiLanguageConfiguration.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/Configuration/MultiLanguage/ExtractMultiLanguageConfiguration.cs
@@ -4,7 +4,7 @@ namespace PnP.Framework.Provisioning.Model.Configuration.MultiLanguage
 {
     public class ExtractMultiLanguageConfiguration
     {
-        [JsonPropertyName("persistMultilanguageResources")]
+        [JsonPropertyName("persistMultiLanguageResources")]
         public bool PersistResources { get; set; }
 
         [JsonPropertyName("resourceFilePrefix")]

--- a/src/lib/PnP.Framework/Provisioning/Model/Configuration/Navigation/ExtractNavigationConfiguration.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/Configuration/Navigation/ExtractNavigationConfiguration.cs
@@ -4,7 +4,7 @@ namespace PnP.Framework.Provisioning.Model.Configuration.Navigation
 {
     public class ExtractNavigationConfiguration
     {
-        [JsonPropertyName("RemoveExistingNodes")]
+        [JsonPropertyName("removeExistingNodes")]
         public bool RemoveExistingNodes { get; set; }
     }
 }


### PR DESCRIPTION
Match JsonPropertyName values in ExtractConfiguration with https://aka.ms/sppnp-extract-configuration-schema .
Some properties has different names set in JsonPropertyName that caused the configuration to not be read correctly from json, for example with command
```powershell
Get-PnPSiteTemplate -out test.xml -Configuration config.json
```

To verify which properties had wrong names I serialized ExtractConfiguration to json and validated the result with the schema.

Fix #214