### PR TITLE
Explicit Catch of System.IO.IOException in ExecuteQueryImplementation…

### DIFF
--- a/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
@@ -203,7 +203,15 @@ namespace Microsoft.SharePoint.Client
                         var errorSb = new System.Text.StringBuilder();
 
                         errorSb.AppendLine(wex.ToString());
-
+                        if (wex.InnerException != null)
+                        {
+                            var socketEx = wex.InnerException as System.Net.Sockets.SocketException;
+                            if (socketEx != null)
+                            {
+                                errorSb.AppendLine($"TraceCorrelationId: {clientContext.TraceCorrelationId}");
+                                errorSb.AppendLine($"SocketErrorCode: {socketEx.SocketErrorCode}");
+                            }
+                        }
                         if (response != null)
                         {
                             //if(response.Headers["SPRequestGuid"] != null) 


### PR DESCRIPTION
#292 Took the Idea with TraceCorrelationId and write this to log by handling IOExpection explicit,
also handle TimeOut with explicit message. Lets see if i can get some input for SSL from Application Insight like this.