### PR TITLE
Fix an issue with possible access of null serverobject in FieldUtilities.FixLookupField

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/FieldUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/FieldUtilities.cs
@@ -16,7 +16,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 if (!Guid.TryParse(listAttr, out Guid g))
                 {
                     var targetList = web.GetListByUrl($"/{listAttr}");
-                    if (targetList != null)
+                    if (targetList != null && targetList.ServerObjectIsNull == false)
                     {
                         fieldElement.SetAttributeValue("List", targetList.Id.ToString("B"));
                         return fieldElement.ToString();


### PR DESCRIPTION
Fixes #309.

Alternative would be to change `ListExtensions.GetListByUrl` to return `null` when `ServerObjectIsNull == true`, as I assume this issue could occur on other places as well... That would however be more of an impact than wanted I assume. :)

Not sure what's the best approach?