### PR TITLE
Fix for issue with provisioning default values for root folder

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2064,6 +2064,30 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             String targetFolderName = parser.ParseString(folder.Name);
             list.SiteList.ParentWeb.EnsureProperties(w => w.ServerRelativeUrl);
 
+            if (targetFolderName == "/" )
+            {
+                // Handle any child-folder
+                if (folder.Folders != null && folder.Folders.Count > 0)
+                {
+                    foreach (var childFolder in folder.Folders)
+                    {
+                        CreateFolderInList(list, parentFolder, childFolder, parser, scope);
+                    }
+                }
+
+                // Handle root folder property bag
+                if (folder.PropertyBagEntries != null && folder.PropertyBagEntries.Count > 0)
+                {
+                    foreach (var p in folder.PropertyBagEntries)
+                    {
+                        parentFolder.Properties[parser.ParseString(p.Key)] = parser.ParseString(p.Value);
+                    }
+                    parentFolder.Update();
+                }
+
+                return;
+            }
+
             // Check if the folder already exists
             if (parentFolder.FolderExists(targetFolderName))
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for an issue that prevented provisioning of default values for a document library root folder. The setting of default values has support for the root folder by using the folder name "/" but when using that the folder creation process failed so this PR fixes that.