### PR TITLE
Fix for valid characters and lower case in site alias

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1743,7 +1743,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         private static string CreateMailNicknameFromDisplayName(string displayName)
         {
-            var mailNickname = displayName.ToLower();
+            var mailNickname = displayName;
             mailNickname = UrlUtility.RemoveUnallowedCharacters(mailNickname);
             mailNickname = UrlUtility.ReplaceAccentedCharactersWithLatin(mailNickname);
             return mailNickname;

--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -224,7 +224,7 @@ namespace PnP.Framework.Sites
                 throw new ArgumentException("Alias cannot contain spaces", "Alias");
             }
 
-            string siteCollectionValidAlias = siteCollectionCreationInformation.Alias.ToLower();
+            string siteCollectionValidAlias = siteCollectionCreationInformation.Alias;
             siteCollectionValidAlias = UrlUtility.RemoveUnallowedCharacters(siteCollectionValidAlias);
             siteCollectionValidAlias = UrlUtility.ReplaceAccentedCharactersWithLatin(siteCollectionValidAlias);
 
@@ -893,7 +893,7 @@ namespace PnP.Framework.Sites
                 throw new ArgumentException("Alias cannot contain spaces", "Alias");
             }
 
-            string siteCollectionValidAlias = siteCollectionGroupifyInformation.Alias.ToLower();
+            string siteCollectionValidAlias = siteCollectionGroupifyInformation.Alias;
             siteCollectionValidAlias = UrlUtility.RemoveUnallowedCharacters(siteCollectionValidAlias);
             siteCollectionValidAlias = UrlUtility.ReplaceAccentedCharactersWithLatin(siteCollectionValidAlias);
             

--- a/src/lib/PnP.Framework/Utilities/UrlUtility.cs
+++ b/src/lib/PnP.Framework/Utilities/UrlUtility.cs
@@ -221,7 +221,7 @@ namespace PnP.Framework.Utilities
 
         public static string RemoveUnallowedCharacters(string str)
         {
-            const string unallowedCharacters = "[&_,!@;:#¤`´~¨='%<>/\\\\\"\\.\\$\\*\\^\\+\\|\\{\\}\\[\\]\\-\\(\\)\\?\\s]";
+            const string unallowedCharacters = "[&,!@;:#¤`´~¨='%<>/\\\\\"\\.\\$\\*\\^\\+\\|\\{\\}\\[\\]\\(\\)\\?\\s]";
             var regex = new Regex(unallowedCharacters);
             return regex.Replace(str, "");
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for an issue that I noticed after a recent PR that changed the behavior of site alias naming. The characters - and _ are valid in site alias and it doesn't have to be lowercase. When creating a new team site using the SharePoint Online start page you are allowed to use - and _ and it doesn't convert site alias to lowercase so I think we should follow the same rules as that oob wizard. We have used the character - in site aliases for a long time and that broke after the recent PR merge.