### PR TITLE
Fix for handling folder default values that are empty in provisioning template

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -256,11 +256,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         {
             foreach (KeyValuePair<string, string> columnValue in templateListFolder.DefaultColumnValues)
             {
-                string fieldName = parser.ParseString(columnValue.Key);
-                var field = listInfo.SiteList.Fields.GetByInternalNameOrTitle(fieldName);
-                var defaultValue =
-                    field.GetDefaultColumnValueFromField((ClientContext)web.Context, folderName, new[] { parser.ParseString(columnValue.Value) });
-                defaultFolderValues.Add(defaultValue);
+                var fieldName = parser.ParseString(columnValue.Key);
+                var fieldValue = parser.ParseString(columnValue.Value);
+                if (!string.IsNullOrEmpty(fieldValue))
+                {
+                    var field = listInfo.SiteList.Fields.GetByInternalNameOrTitle(fieldName);
+                    var defaultValue = field.GetDefaultColumnValueFromField((ClientContext)web.Context, folderName, new[] { fieldValue });
+                    defaultFolderValues.Add(defaultValue);
+                }
             }
             foreach (var folder in templateListFolder.Folders)
             {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for an issue that appears when trying to provision a template that contains folder default values that are empty, e.g. when using parameters that sometimes has an empty value.