### PR TITLE
Fix:  team site creation issue

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -321,8 +321,11 @@ namespace PnP.Framework.Sites
             if (siteCollectionCreationInformation.SiteDesignId.HasValue)
             {
                 creationOptionsValues.Add($"implicit_formula_292aa8a00786498a87a5ca52d9f4214a_{siteCollectionCreationInformation.SiteDesignId.Value.ToString("D").ToLower()}");
-            }                            
-            creationOptionsValues.Add($"SPSiteLanguage:{siteCollectionCreationInformation.Lcid}");            
+            }
+            if (siteCollectionCreationInformation.Lcid != 0)
+            {
+                creationOptionsValues.Add($"SPSiteLanguage:{siteCollectionCreationInformation.Lcid}");
+            }
             if (!string.IsNullOrEmpty(siteCollectionCreationInformation.SiteAlias))
             {
                 creationOptionsValues.Add($"SiteAlias:{siteCollectionCreationInformation.SiteAlias}");


### PR DESCRIPTION
Fix:  team site creation issue. Looks like there is some change in the API. Earlier it used to accept LCID value as 0 but now it is more strict and that's why failing. 

Added a check here to skip setting LCID value if it is 0.