### PR TITLE
TaxonomyExtensions - NormalizeName - hasGuid true if IndexOf | == -1

### DIFF
--- a/src/lib/PnP.Framework/Extensions/TaxonomyExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/TaxonomyExtensions.cs
@@ -1459,7 +1459,7 @@ namespace Microsoft.SharePoint.Client
         public static string NormalizeName(string name)
         {
             if (name == null) return null;
-            var hasGuid = name.IndexOf("|") > -1;
+            var hasGuid = name.IndexOf("|") == -1;
 
             var nameToNormalize = hasGuid ? name.Split('|')[0] : name;
 


### PR DESCRIPTION
"|" is an indicator for a path (at least in other places of the implementation) and not for a Guid.

You may also switch to Guid.TryParse(...) which is more consistent if you want to check for Guid and not for a single element

https://docs.microsoft.com/en-us/dotnet/api/system.guid.tryparse?view=net-5.0