### PR TITLE
Feature - Bumped DLL versions

### DIFF
--- a/src/lib/PnP.Framework/PnP.Framework.csproj
+++ b/src/lib/PnP.Framework/PnP.Framework.csproj
@@ -205,7 +205,7 @@
 
 	<ItemGroup>
 		<!-- Required -->
-		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.16.2" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.4" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
 		<PackageReference Include="AngleSharp" Version="0.14.0" />
 		<PackageReference Include="AngleSharp.Css" Version="0.14.2" />
@@ -215,15 +215,15 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Data.OData" Version="5.8.4" />
-		<PackageReference Include="Microsoft.Graph" Version="3.19.0" />
-		<PackageReference Include="Microsoft.Graph.Core" Version="1.22.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.21.0" />
+		<PackageReference Include="Microsoft.Graph" Version="3.33.0" />
+		<PackageReference Include="Microsoft.Graph.Core" Version="1.25.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.30.1" />
 		<PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.*" />
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="PnP.Core" Version="1.1.*-*" Condition="'$(PnPCoreSdkPath)' == ''" />
 		<PackageReference Include="Portable.Xaml" Version="0.26.0" />
 		<PackageReference Include="ResXResourceReader.NetStandard" Version="1.0.1" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.11.1" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(PnPCoreSdkPath)' != ''">


### PR DESCRIPTION
Bumped DLL versions for Graph and MSAL.

Had to bump MSAL as it is causing issues with Az modules. 

@ Bert - can you also please update in PnP Core if possible, somehow I couldn't get the build working there on a freshly cloned repo ? 

This PR (https://github.com/pnp/powershell/pull/765) depends on merge of this request and also the one in PnP Core