### PR TITLE
Added JsonConvertor decorator to UpdateBehavior

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Model/Configuration/Lists/Lists/ExtractListsListsConfiguration.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/Configuration/Lists/Lists/ExtractListsListsConfiguration.cs
@@ -14,6 +14,7 @@ namespace PnP.Framework.Provisioning.Model.Configuration.Lists.Lists
         public string KeyColumn { get; set; }
 
         [JsonPropertyName("updateBehavior")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public UpdateBehavior UpdateBehavior { get; set; }
 
         [JsonPropertyName("skipEmptyFields")]


### PR DESCRIPTION
## Issue
When using the PnP.PowerShell command `Get-PnPSiteTemplate` with a configuration file if you specify the `updateBehavior` property for a list, the entire configuration file is ignored with no error message.

### Steps to Recreate
1. Create a config file like this named config.json:
```JSON
{
    "$schema":"https://aka.ms/sppnp-extract-configuration-schema",
    "handlers": [
        "Lists"
    ],
    "lists": {
        "lists": [
            {
                "title": "Bar Graph",
                "includeItems": true,
                "updateBehavior": "Skip",
                "keyColumn": "Title"
            }
        ]
    }
}
```
2. Change the title to a list on your site
3. Connect to the site in PnP.PowerShell
4. Run this command
```Terminal
Get-PnPSiteTemplate -Configuration config.json -Out template.xml
```

The entire template will be extracted as if you didn't specify a configuration at all.

### What's happening
When [PnP.PowerShell calls `ExtractConfiguration.FromString`](https://github.com/pnp/powershell/blob/bb1606603d7ef1b2043dd36b428352d8bcf66dd7/src/Commands/Base/PipeBinds/ExtractConfigurationPipeBind.cs#L40) a deserialization error is thrown. Unfortunately, this error is swallowed since the exception is unhandled (that's a separate issue).

The issue is that UpdateBehavior is an enum and so as is it expects the JSON value to be an integer - NOT a string.

## The Fix
Adding a `[JsonConverter(typeof(JsonStringEnumConverter))]` decorator to the property fixes the issue.