### PR TITLE
Fix so that teams apps are added before channels

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -84,8 +84,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 {
                     if (!SetGroupSecurity(scope, parser, team, teamId, accessToken)) return null;
                 }
-                if (!SetTeamChannels(scope, parser, team, teamId, accessToken)) return null;
                 if (!SetTeamApps(scope, parser, team, teamId, accessToken)) return null;
+                if (!SetTeamChannels(scope, parser, team, teamId, accessToken)) return null;
 
                 // So far the Team's photo cannot be set if we don't have an already existing mailbox
                 if (!SetTeamPhoto(scope, parser, connector, team, teamId, accessToken)) return null;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for an issue that appears when trying to provision a teams tab with a custom app from the app catalog. The app needs to have been added to the team before a tab that references the app can be added.