### PR TITLE
Added new provisioning token for using sequence site tokens in global template context

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
@@ -674,6 +674,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                     RESTUtilities.ExecuteGetAsync(web, "/_api/web/hubsitedata(true)").GetAwaiter().GetResult();
                                 }
 
+                                foreach (var token in siteTokenParser.Tokens)
+                                {
+                                    foreach (var t in token.GetTokens())
+                                    {
+                                        tokenParser.AddToken(new SequenceSiteTokenToken(null, sitecollection.ProvisioningId, t, token.GetReplaceValue()));
+                                    }
+                                }
                             }
 
                         }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/SequenceSiteTokenToken.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/SequenceSiteTokenToken.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.SharePoint.Client;
+using PnP.Framework.Attributes;
+
+namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
+{
+    [TokenDefinitionDescription(
+        Token = "{sequencesitetoken:[provisioningid]:[siteTokenName]}",
+        Description = "Returns the value of the named token in the specified site provisioning sequence",
+        Example = "{sequencesitetoken:MYID:listid:My List}",
+        Returns = "c7d9f9aa-4696-4c27-8a22-7d8eb7e70fda")]
+    internal class SequenceSiteTokenToken : TokenDefinition
+    {
+        private string _value;
+        public SequenceSiteTokenToken(Web web, string provisioningId, string siteTokenName, string siteTokenValue)
+            : base(web, $"{{sequencesitetoken:{provisioningId}:{siteTokenName.Trim('{', '}')}}}")
+        {
+            _value = siteTokenValue;
+        }
+
+        public override string GetReplaceValue()
+        {
+            return _value;
+        }
+    }
+}

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenParser.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenParser.cs
@@ -1214,16 +1214,27 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     {
                         if (!ReGuid.IsMatch(match.Groups[i].Value))
                         {
-                            string tokenString = match.Groups[i].Value.Replace("{", "").Replace("}", "").ToLower();
+                            var originalTokenString = match.Groups[i].Value.Replace("{", "").Replace("}", "").ToLower();
 
-                            var colonIndex = tokenString.IndexOf(":");
+                            var tokenStringToAdd = originalTokenString;
+                            var colonIndex = tokenStringToAdd.IndexOf(":");
                             if (colonIndex > -1)
                             {
-                                tokenString = tokenString.Substring(0, colonIndex);
+                                tokenStringToAdd = tokenStringToAdd.Substring(0, colonIndex);
                             }
-                            if (!tokenIds.Contains(tokenString) && !string.IsNullOrEmpty(tokenString))
+                            if (!tokenIds.Contains(tokenStringToAdd) && !string.IsNullOrEmpty(tokenStringToAdd))
                             {
-                                tokenIds.Add(tokenString);
+                                tokenIds.Add(tokenStringToAdd);
+                            }
+
+                            // If sequencesitetoken is used we need to make sure that the corresponding site token is also loaded
+                            if (tokenStringToAdd == "sequencesitetoken")
+                            {
+                                var sequenceSiteTokenArray = originalTokenString.Split(':');
+                                if (sequenceSiteTokenArray.Length > 2 && !string.IsNullOrWhiteSpace(sequenceSiteTokenArray[2]) && !tokenIds.Contains(sequenceSiteTokenArray[2]))
+                                {
+                                    tokenIds.Add(sequenceSiteTokenArray[2]);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Added a new token called sequencesitetoken to be used to get to specific sequence site tokens in the global template context. This way you can for example use site tokens in Teams channel messages or Teams tabs configurations which was not possible before.

Usage example: ```{sequencesitetoken:MYID:listid:My List}```

I would also like to contribute documentation for this but cannot find anything around the tokens except this one for PnP-SItes-Core which has been archived: [Office 365 Developer PnP Core Component Provisioning Engine Tokens](https://github.com/pnp/PnP-Sites-Core/blob/master/Core/ProvisioningEngineTokens.md). Where should the documentation around the tokens be kept?