### PR TITLE
Added configuration settings for SharePoint tab entity inside Teams

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1176,7 +1176,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         }
                     case "2a527703-1f6f-4559-a332-d8a7d288cd88": // SharePoint page and lists
                         {
-                            tab.Configuration = null;
+                            tab.Configuration.EntityId = parser.ParseString(tab.Configuration.EntityId);
+                            tab.Configuration.ContentUrl = parser.ParseString(tab.Configuration.ContentUrl);
+                            tab.Configuration.RemoveUrl = parser.ParseString(tab.Configuration.RemoveUrl);
+                            tab.Configuration.WebsiteUrl = parser.ParseString(tab.Configuration.WebsiteUrl);
                             break;
                         }
                     default:


### PR DESCRIPTION
Configuration for SharePoint tab was empty. Basically, we have detected an issue trying to use de Website tab with a SharePoint site collection url, it works but all links inside that page loaded from the tab are not working. We have checked that they work if the tab is a SharePoint tab.