### PR TITLE
Add support to ClearExistingItems attribute of <pnp:Members> for custom groups

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -373,6 +373,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             g => g.RequestToJoinLeaveEmailSetting,
                             g => g.Owner.LoginName);
                         web.Context.ExecuteQueryRetry();
+
+                        if (siteGroup.ClearExistingMembers)
+                        {
+                            ClearExistingUsers(group);
+                        }
+
                         parser.AddToken(new GroupIdToken(web, group.Title, group.Id.ToString()));
 
                         var groupNeedsUpdate = false;


### PR DESCRIPTION
Add support to ClearExistingItems attribute of <pnp:Members> for custom groups.
Before this PR the attribute ClearExistingItems was checked only for Associated Owners/Members/Visitors group.
https://github.com/pnp/PnP-Provisioning-Schema/blob/master/ProvisioningSchema-2021-03.md#userslist is the affected field in the provisioning schema.

Close #243 (even if it was closed already as old)
Close #379

I tested a small template without the field, with the field set to false and with the field set to true and it worked as expected in all 3 cases.

```xml
<?xml version="1.0"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2020/02/ProvisioningSchema">
  <pnp:Preferences Generator="OfficeDevPnP.Core, Version=3.22.2006.2, Culture=neutral, PublicKeyToken=5e633289e95c321a" />
  <pnp:Templates ID="CONTAINER-TEMPLATE-94F2A9FBD42A4426A711EFE6606EE94E">
    <pnp:ProvisioningTemplate ID="TEMPLATE-94F2A9FBD42A4426A711EFE6606EE94E" Version="1" BaseSiteTemplate="GROUP#0" Scope="RootSite">
      <pnp:Security AssociatedOwnerGroup="TEST Owners" AssociatedMemberGroup="TEST Members" AssociatedVisitorGroup="TEST Visitors">
        <pnp:SiteGroups>
          <pnp:SiteGroup Title="Power Users" Description="Group of Power Users" Owner="user1@contoso.com">
            <pnp:Members ClearExistingItems="true">
              <pnp:User Name="user2@contoso.com" />
            </pnp:Members>
          </pnp:SiteGroup>
        </pnp:SiteGroups>
      </pnp:Security>
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```