### PR TITLE
Fix for content type UpdateChildren not being used

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectContentType.cs
@@ -255,6 +255,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             // Should child content types be updated.
             bool UpdateChildren()
             {
+                if (!templateContentType.UpdateChildren)
+                {
+                    return false;
+                }
                 if (fieldsNotPresentInTarget.Any())
                 {
                     return !templateContentType.FieldRefs.All(f => f.UpdateChildren == false);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix so that the content type UpdateChildren provisioning template property actually is being used when updating content types using PnP provisioning. Before this this was always True.