### PR TITLE
Fix pnpcontext cache did not work for multitenant

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -93,6 +93,8 @@ namespace PnP.Framework
         private IMsalHttpClientFactory httpClientFactory;
         private readonly SecureString accessToken;
         private readonly IAuthenticationProvider authenticationProvider;
+        private readonly PnPContext pnpContext;
+
         internal CookieContainer CookieContainer { get; set; }
 
         private IMsalHttpClientFactory HttpClientFactory
@@ -261,6 +263,16 @@ namespace PnP.Framework
         public static AuthenticationManager CreateWithPnPCoreSdk(IAuthenticationProvider authenticationProvider)
         {
             return new AuthenticationManager(authenticationProvider);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the Authentication Manager to acquire an authenticated ClientContext.
+        /// </summary>
+        /// <param name="pnpContext">PnP Core SDK authentication provider that will deliver the access token</param>
+        /// <returns></returns>
+        public static AuthenticationManager CreateWithPnPCoreSdk(PnPContext pnpContext)
+        {
+            return new AuthenticationManager(pnpContext);
         }
         #endregion
 
@@ -603,6 +615,18 @@ namespace PnP.Framework
         public AuthenticationManager(IAuthenticationProvider authenticationProvider)
         {
             this.authenticationProvider = authenticationProvider;
+            this.pnpContext = null;
+            authenticationType = ClientContextType.PnPCoreSdk;
+        }
+
+        /// <summary>
+        /// Creates an AuthenticationManager for the given PnP Core SDK
+        /// </summary>
+        /// <param name="pnPContext">PnP Core SDK<see cref="PnPContext"/></param>
+        public AuthenticationManager(PnPContext pnPContext)
+        {
+            this.authenticationProvider = pnPContext.AuthenticationProvider;
+            this.pnpContext = pnPContext;
             authenticationType = ClientContextType.PnPCoreSdk;
         }
         #endregion
@@ -1000,14 +1024,15 @@ namespace PnP.Framework
             }
             return null;
         }
-        #endregion
 
-
+        /// <summary>
+        /// Return same IAuthenticationProvider then the AuthenticationManager was initialized with
+        /// </summary>
         internal IAuthenticationProvider PnPCoreAuthenticationProvider { 
             get {
-                if (authenticationType == ClientContextType.PnPCoreSdk)
+                if (authenticationType == ClientContextType.PnPCoreSdk && authenticationProvider != null)
                 {
-                    return this.authenticationProvider;
+                    return authenticationProvider;
                 }
                 else
                 {
@@ -1015,6 +1040,25 @@ namespace PnP.Framework
                 }
             } 
         }
+
+        /// <summary>
+        /// Return same PnPContext then the AuthenticationManager was initialized with
+        /// </summary>
+        internal PnPContext PnPCoreContext
+        {
+            get
+            {
+                if (authenticationType == ClientContextType.PnPCoreSdk && pnpContext!=null)
+                {
+                    return pnpContext;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+        #endregion
 
         #region Internals
         private ClientContext BuildClientContext(IClientApplicationBase application, string siteUrl, string[] scopes, ClientContextType contextType)

--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -1002,6 +1002,20 @@ namespace PnP.Framework
         }
         #endregion
 
+
+        internal IAuthenticationProvider PnPCoreAuthenticationProvider { 
+            get {
+                if (authenticationType == ClientContextType.PnPCoreSdk)
+                {
+                    return this.authenticationProvider;
+                }
+                else
+                {
+                    return null;
+                }
+            } 
+        }
+
         #region Internals
         private ClientContext BuildClientContext(IClientApplicationBase application, string siteUrl, string[] scopes, ClientContextType contextType)
         {

--- a/src/lib/PnP.Framework/PnPCoreSdk.cs
+++ b/src/lib/PnP.Framework/PnPCoreSdk.cs
@@ -47,16 +47,27 @@ namespace PnP.Framework
         public PnPContext GetPnPContext(ClientContext context)
         {
             Uri ctxUri = new Uri(context.Url);
-            var factory = BuildContextFactory();
+           
             var ctxSettings = context.GetContextSettings();
-            if(ctxSettings!=null && ctxSettings.AuthenticationManager!=null)
+            
+            if (ctxSettings!=null && ctxSettings.Type == Utilities.Context.ClientContextType.PnPCoreSdk && ctxSettings.AuthenticationManager!=null)
             {
-                var iAuthProvider = ctxSettings.AuthenticationManager.PnPCoreAuthenticationProvider;
-                if(iAuthProvider!=null)
+                var pnpContext = ctxSettings.AuthenticationManager.PnPCoreContext;
+                if (pnpContext != null)
                 {
-                    return factory.Create(ctxUri, iAuthProvider);
+                    return pnpContext;
+                }
+                else
+                {
+                    var iAuthProvider = ctxSettings.AuthenticationManager.PnPCoreAuthenticationProvider;
+                    if (iAuthProvider != null)
+                    {
+                        var factory0 = BuildContextFactory();
+                        return factory0.Create(ctxUri, iAuthProvider);
+                    }
                 }
             }
+            var factory = BuildContextFactory();
             return factory.Create(ctxUri, AuthenticationProviderFactory.GetAuthenticationProvider(context));
         }
 
@@ -116,7 +127,7 @@ namespace PnP.Framework
         public ClientContext GetClientContext(PnPContext pnpContext)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-            AuthenticationManager authManager = AuthenticationManager.CreateWithPnPCoreSdk(pnpContext.AuthenticationProvider);
+            AuthenticationManager authManager = AuthenticationManager.CreateWithPnPCoreSdk(pnpContext);
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
             var ctx = authManager.GetContext(pnpContext.Uri.ToString());


### PR DESCRIPTION
The way we had the pnpContextCached in PnPCoreSdk we would get potentialy wrong pnpcontext as we cloud have GetClientContext started from User or App Only Context.