### PR TITLE
Better fix for issue 390. Now it waits 5 secs between each retry.

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -475,7 +475,11 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     CoreResources.Provisioning_ObjectHandlers_Teams_Team_ProvisioningError,
                     canPatch: true);
 
-                    if (!string.IsNullOrEmpty(teamId))
+                    if (string.IsNullOrEmpty(teamId)) // Currently GraphHelper.CreateOrUpdateGraphObject is not throwing Exceptions, but returning TeamId null
+                    {
+                        System.Threading.Thread.Sleep(TimeSpan.FromSeconds(5));
+                    }
+                    else
                     {
                         wait = false;
                     }


### PR DESCRIPTION
Sorry @jansenbe but my previous fix was not good enough, and I detected it can still fail sometimes. Now it also waits 5 seconds between retries in case the TeamId is returned null by the GraphHelper method. I´ve already tested it in my project and is working as expected.
Thanks.