### PR TITLE
Fix TokenParser always returns original associated-group-names

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/AssociatedGroupToken.cs
@@ -26,6 +26,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
             : base(web, $"{{associated{groupType.ToString().TrimEnd('s')}group}}")
         {
             _groupType = groupType;
+            IsCacheable = false; //since TokenParser does not Update TokenDictionary in BuildTokenCache if IsCacheable=true and therefore not get the new group names after ObjectSiteSecurity renamed groups
         }
 
         internal AssociatedGroupType GroupType { get => _groupType; set => _groupType = value; }


### PR DESCRIPTION
Fix TokenParser always returns original associated-group-names even when renamed by ObjectSiteSecurity.
Since SecurableObjectExtensions will not be able to resolve the old Group-Names the security will not be applied to the objects as they be removed by CheckForAndRemoveNonExistingPrincipals.