### PR TITLE
GetWebSearchCenterUrl makes us loose the pending changes in CSOM Context

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectWebSettings.cs
@@ -391,13 +391,6 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         web.SearchBoxInNavBar = (SearchBoxInNavBarType)Enum.Parse(typeof(SearchBoxInNavBarType), webSettings.SearchBoxInNavBar.ToString(), true);
                     }
 
-                    string searchCenterUrl = parser.ParseString(webSettings.SearchCenterUrl);
-                    if (!string.IsNullOrEmpty(searchCenterUrl) &&
-                        web.GetWebSearchCenterUrl(true) != searchCenterUrl)
-                    {
-                        web.SetWebSearchCenterUrl(searchCenterUrl);
-                    }
-
                     var masterUrl = parser.ParseString(webSettings.MasterPageUrl);
                     if (!string.IsNullOrEmpty(masterUrl))
                     {
@@ -509,6 +502,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                     web.Update();
                     web.Context.ExecuteQueryRetry();
+
+                    //GetWebSearchCenterUrl makes us loose the pending changes in CSOM Context
+                    string searchCenterUrl = parser.ParseString(webSettings.SearchCenterUrl);
+                    if (!string.IsNullOrEmpty(searchCenterUrl) &&
+                        web.GetWebSearchCenterUrl(true) != searchCenterUrl)
+                    {
+                        web.SetWebSearchCenterUrl(searchCenterUrl);
+                    }
 
                     if (webSettings.HubSiteUrl != null)
                     {


### PR DESCRIPTION
moved searchcenterurl parsing below the commit of pending requests in ObjectWebSettings because the call to web.GetWebSearchCenterUrl(true) makes us otherwise loose the pending settings.