### PR TITLE
Including the requested SelectProperties in the output of ListUsers

### DIFF
--- a/src/lib/PnP.Framework/Graph/UsersUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UsersUtility.cs
@@ -149,6 +149,21 @@ namespace PnP.Framework.Graph
                                     AccountEnabled = u.AccountEnabled,
                                 };
 
+                                // If additional properties have been provided, ensure their output gets added to the AdditionalProperties dictonary of the output
+                                if (selectProperties != null)
+                                {
+                                    foreach (var selectProperty in selectProperties)
+                                    {
+                                        // Ensure the requested property has been returned in the response
+                                        var property = u.GetType().GetProperty(selectProperty);
+                                        if (property != null)
+                                        {
+                                            // Add the property to the AdditionalProperties dictionary
+                                            user.AdditionalProperties.Add(selectProperty, property.GetValue(u));
+                                        }
+                                    }
+                                }
+
                                 users.Add(user);
                             }
                         }


### PR DESCRIPTION
When calling into ListUsers providing additional properties to return using SelectProperties, the results are not getting included in the response. Fixed that with this PR.

Reported through PnP PowerShell [issue 649](https://github.com/pnp/powershell/issues/649).