### PR TITLE
Fixing GetGroupMembers and GetGroupOwners

### DIFF
--- a/src/lib/PnP.Framework/Entities/GroupUser.cs
+++ b/src/lib/PnP.Framework/Entities/GroupUser.cs
@@ -1,18 +1,25 @@
-﻿namespace PnP.Framework.Entities
+﻿using PnP.Framework.Enums;
+
+namespace PnP.Framework.Entities
 {
     /// <summary>
-    /// Defines a Group user
+    /// Defines an user or group located in a Azure Active Directory Group
     /// </summary>
     public class GroupUser
     {
         /// <summary>
-        /// Group user's user principal name
+        /// Group user's user principal name or Group Id
         /// </summary>
         public string UserPrincipalName { get; set; }
+
         /// <summary>
-        /// Group user's display name
+        /// Group user's or group's display name
         /// </summary>
         public string DisplayName { get; set; }
 
+        /// <summary>
+        /// Indication if this entry represents a user or a group
+        /// </summary>
+        public GroupUserType Type { get; set; }
     }
 }

--- a/src/lib/PnP.Framework/Enums/GroupUserType.cs
+++ b/src/lib/PnP.Framework/Enums/GroupUserType.cs
@@ -1,0 +1,18 @@
+namespace PnP.Framework.Enums
+{
+    /// <summary>
+    /// Enum that defines the GroupUser types
+    /// </summary>
+    public enum GroupUserType
+    {
+        /// <summary>
+        /// GroupUser represents a user
+        /// </summary>
+        User = 0,
+        
+        /// <summary>
+        /// GroupUser represents a group
+        /// </summary>
+        Group = 1
+    }
+}

--- a/src/lib/PnP.Framework/Graph/GroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/GroupsUtility.cs
@@ -683,7 +683,7 @@ namespace PnP.Framework.Graph
         public static List<GroupUser> GetGroupMembers(GroupEntity group, string accessToken, int retryCount = 10, int delay = 500)
         {
             List<GroupUser> groupUsers = null;
-            List<User> groupGraphUsers = null;
+            List<DirectoryObject> groupGraphUsers = null;
             IGroupMembersCollectionWithReferencesPage groupUsersCollection = null;
 
             if (String.IsNullOrEmpty(accessToken))
@@ -705,9 +705,9 @@ namespace PnP.Framework.Graph
                     groupUsersCollection = await graphClient.Groups[group.GroupId].Members.Request().GetAsync();
                     if (groupUsersCollection.CurrentPage != null && groupUsersCollection.CurrentPage.Count > 0)
                     {
-                        groupGraphUsers = new List<User>();
-
-                        GenerateGraphUserCollection(groupUsersCollection.CurrentPage, groupGraphUsers);
+                        groupGraphUsers = new List<DirectoryObject>();
+                        groupGraphUsers.AddRange(groupUsersCollection.CurrentPage);
+                        //GenerateGraphUserCollection(groupUsersCollection.CurrentPage, groupGraphUsers);
                     }
 
                     // Retrieve users when the results are paged.
@@ -716,7 +716,8 @@ namespace PnP.Framework.Graph
                         groupUsersCollection = groupUsersCollection.NextPageRequest.GetAsync().GetAwaiter().GetResult();
                         if (groupUsersCollection.CurrentPage != null && groupUsersCollection.CurrentPage.Count > 0)
                         {
-                            GenerateGraphUserCollection(groupUsersCollection.CurrentPage, groupGraphUsers);
+                            groupGraphUsers.AddRange(groupUsersCollection.CurrentPage);
+                            //GenerateGraphUserCollection(groupUsersCollection.CurrentPage, groupGraphUsers);
                         }
                     }
 
@@ -724,14 +725,29 @@ namespace PnP.Framework.Graph
                     if (groupGraphUsers != null && groupGraphUsers.Count > 0)
                     {
                         groupUsers = new List<GroupUser>();
-                        foreach (User usr in groupGraphUsers)
+                        foreach (DirectoryObject usr in groupGraphUsers)
                         {
-                            GroupUser groupUser = new GroupUser
+                            switch(usr)
                             {
-                                UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty,
-                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty
-                            };
-                            groupUsers.Add(groupUser);
+                                case Microsoft.Graph.User userType:
+                                    groupUsers.Add(new GroupUser
+                                    {
+                                        UserPrincipalName = userType.UserPrincipalName != null ? userType.UserPrincipalName : string.Empty,
+                                        DisplayName = userType.DisplayName != null ? userType.DisplayName : string.Empty,
+                                        Type = Enums.GroupUserType.User
+                                    });
+                                break;
+
+                                case Microsoft.Graph.Group groupType:
+                                    groupUsers.Add(new GroupUser
+                                    {
+                                        UserPrincipalName = groupType.Id != null ? groupType.Id : string.Empty,
+                                        DisplayName = groupType.DisplayName != null ? groupType.DisplayName : string.Empty,
+                                        Type = Enums.GroupUserType.Group
+                                    });
+                                    break;
+                            }
+
                         }
                     }
                     return groupUsers;
@@ -1021,14 +1037,29 @@ namespace PnP.Framework.Graph
                     if (groupGraphUsers != null && groupGraphUsers.Count > 0)
                     {
                         groupUsers = new List<GroupUser>();
-                        foreach (User usr in groupGraphUsers)
+                        foreach (DirectoryObject usr in groupGraphUsers)
                         {
-                            GroupUser groupUser = new GroupUser
+                            switch(usr)
                             {
-                                UserPrincipalName = usr.UserPrincipalName != null ? usr.UserPrincipalName : string.Empty,
-                                DisplayName = usr.DisplayName != null ? usr.DisplayName : string.Empty
-                            };
-                            groupUsers.Add(groupUser);
+                                case Microsoft.Graph.User userType:
+                                    groupUsers.Add(new GroupUser
+                                    {
+                                        UserPrincipalName = userType.UserPrincipalName != null ? userType.UserPrincipalName : string.Empty,
+                                        DisplayName = userType.DisplayName != null ? userType.DisplayName : string.Empty,
+                                        Type = Enums.GroupUserType.User
+                                    });
+                                break;
+
+                                case Microsoft.Graph.Group groupType:
+                                    groupUsers.Add(new GroupUser
+                                    {
+                                        UserPrincipalName = groupType.Id != null ? groupType.Id : string.Empty,
+                                        DisplayName = groupType.DisplayName != null ? groupType.DisplayName : string.Empty,
+                                        Type = Enums.GroupUserType.Group
+                                    });
+                                    break;
+                            }
+
                         }
                     }
                     return groupUsers;


### PR DESCRIPTION
Fixing GetGroupMembers and GetGroupOwners throwing an exception when a Security Group is placed in the group that is being queried. I believe in the way I have added support for retrieving Security Groups in AAD Groups is backwards compatible. Please verify if you agree.

Reported through https://github.com/pnp/powershell/issues/1204