### PR TITLE
Fix for false positive exception logging in GetPrincipalUniqueRoleAssignments

### DIFF
--- a/src/lib/PnP.Framework/Extensions/SecurityExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/SecurityExtensions.cs
@@ -1522,22 +1522,26 @@ namespace Microsoft.SharePoint.Client
                 }
 
                 RoleAssignment assignment;
-                try
+                var scope = new ExceptionHandlingScope(web.Context);
+
+                using (scope.StartScope())
                 {
-                    assignment = obj.RoleAssignments.GetByPrincipal(principal);
-                    web.Context.ExecuteQueryRetry();
+                    using (scope.StartTry())
+                    {
+
+                        assignment = obj.RoleAssignments.GetByPrincipal(principal);
+                    }
+
+                    using (scope.StartCatch())
+                    {
+                    }
                 }
-                catch (ServerException ex)
+
+                web.Context.ExecuteQueryRetry();
+
+                if (scope.HasException)
                 {
-                    if (ex.HResult == -2146233088)
-                    {
-                        // Can not find the principal so suppress the exception
-                        assignment = null;
-                    }
-                    else
-                    {
-                        throw;
-                    }
+                    assignment = null;
                 }
 
                 if (assignment != null)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Replaces try-catch with ExceptionHandlingScope so that false positive exceptions are not logged when using GetPrincipalUniqueRoleAssignments. Before this an exception was logged for every securable object that did not have a specific role assignment for the provided principal.