### PR TITLE
fix for issue with empty description in UserCustomActions 

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectCustomActions.cs
@@ -431,7 +431,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     customAction.Title = customActionTitle;
 
                 }
-                if (UserResourceExtensions.PersistResourceValue(userCustomAction.DescriptionResource, $"CustomAction_{resourceKey}_Description", template, creationInfo))
+                if (!string.IsNullOrWhiteSpace(userCustomAction.Description) && UserResourceExtensions.PersistResourceValue(userCustomAction.DescriptionResource, $"CustomAction_{resourceKey}_Description", template, creationInfo))
                 {
                     var customActionDescription = $"{{res:CustomAction_{resourceKey}_Description}}";
                     customAction.Description = customActionDescription;


### PR DESCRIPTION
fix for issue with empty description in UserCustomActions if PageTranslation is turned on. As it seems unrelated, still we can prove in multiple tenant's that as soon as PageTranslation is turned on GetValueForUICulture will throw an error if the Description of the UserCustomAction is not set.