### PR TITLE
Fixing issue when trying to export datarow for list instances

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -610,7 +610,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             // We process real values only
                             if (value != null && !String.IsNullOrEmpty(value) && value != "[]")
                             {
-                                pnpFile.Properties.Add(fieldValue.Key, value);
+                                pnpFile.Properties[fieldValue.Key] = value;
                             }
                         }
                     }


### PR DESCRIPTION
There is an issue in the code that is preventing to export properties for files from libraries when there are several content types.
Not sure if affects to more cases. 
In line 587, code is adding ContentTypeId to the pnpFile.Properties. In line 613, was trying to add again the same property key to the dictionary, that was raising an issue.
Changing the way to add properties to the dictionary, it will overwrite it if exists.
![image](https://user-images.githubusercontent.com/8925463/143228874-afb2eaf6-15f3-46d6-b868-782f2b3ebbf8.png)
