### PR TITLE
Fix for Null Exception when trying to set a term value in a file, listItem, and the term label contains a comma

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -420,7 +420,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                                             clonedContext.Load(taxonomyItem);
                                             clonedContext.ExecuteQueryRetry();
                                         }
-                                        terms.Add(new KeyValuePair<Guid, string>(taxonomyItem.Id, taxonomyItem.Name));
+                                        if (taxonomyItem!=null)
+                                            terms.Add(new KeyValuePair<Guid, string>(taxonomyItem.Id, taxonomyItem.Name));
                                     }
 
                                     TaxonomyField taxField = context.CastTo<TaxonomyField>(field);


### PR DESCRIPTION
Checking taxonomyItem before adding it to the List of terms.
If taxonomyItem was null, it was giving an exception.
#540 