### PR TITLE
Update SiteCollectionCreationInformation.cs

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
@@ -300,11 +300,12 @@ namespace PnP.Framework.Sites
 
         }
 
-        public SiteCreationGroupInformation(string alias, string displayName, string description = null)
+        public SiteCreationGroupInformation(string alias, string displayName, string description = null, string sitealias)
         {
             this.Alias = alias;
             this.DisplayName = displayName;
             this.Description = description;
+            this.SiteAlias = sitealias;
         }
     }
 


### PR DESCRIPTION
The Site Alias variable is declared but not used. 

According to the documentation https://docs.microsoft.com/en-us/powershell/module/sharepoint-pnp/new-pnpsite?view=sharepoint-ps example 10 , sitealias can be used to specify the Url of the team site. Can it reinstated as amended in the change?