### PR TITLE
Fix for Culture is not supported exception

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -322,11 +322,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         throw new Exception(CoreResources.SiteToTemplateConversion_ScopeOfTemplateDoesNotMatchTarget);
                     }
                 }
-                var currentCultureInfoValue = System.Threading.Thread.CurrentThread.CurrentCulture.LCID;
+                var currentCultureInfoValue = System.Threading.Thread.CurrentThread.CurrentCulture;
                 if (!string.IsNullOrEmpty(template.TemplateCultureInfo))
                 {
-                    int cultureInfoValue = System.Threading.Thread.CurrentThread.CurrentCulture.LCID;
-                    if (int.TryParse(template.TemplateCultureInfo, out cultureInfoValue))
+                    if (int.TryParse(template.TemplateCultureInfo, out var cultureInfoValue))
                     {
                         System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(cultureInfoValue);
                     }
@@ -473,7 +472,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 CallWebHooks(template, tokenParser, ProvisioningTemplateWebhookKind.ProvisioningTemplateCompleted);
 
-                System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo(currentCultureInfoValue);
+                System.Threading.Thread.CurrentThread.CurrentCulture = currentCultureInfoValue;
 
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
Fix for an exception that occurs while provisioning if using .NET 6 and CurrentCulture is set to a non-standard one e.g. en-SE or en-BE. For more info see [.NET misreports current culture after upgrading to .NET6](https://github.com/dotnet/runtime/issues/60296)