### PR TITLE
Fix to trim unaccepted chars from SiteAlias

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -328,7 +328,11 @@ namespace PnP.Framework.Sites
             }
             if (!string.IsNullOrEmpty(siteCollectionCreationInformation.SiteAlias))
             {
-                creationOptionsValues.Add($"SiteAlias:{siteCollectionCreationInformation.SiteAlias}");
+                string siteAlias = siteCollectionCreationInformation.SiteAlias;
+                siteAlias = UrlUtility.RemoveUnallowedCharacters(siteAlias);
+                siteAlias = UrlUtility.ReplaceAccentedCharactersWithLatin(siteAlias);
+                
+                creationOptionsValues.Add($"SiteAlias:{siteAlias}");
             }
             creationOptionsValues.Add($"HubSiteId:{siteCollectionCreationInformation.HubSiteId}");
             optionalParams.Add("CreationOptions", creationOptionsValues);


### PR DESCRIPTION
Fix to trim unaccepted chars from the SiteAlias as well.

We already fixed it for Alias property, added the same fix for SiteAlias property