### PR TITLE
Added localization support for child nodes in footer

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -445,12 +445,18 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                     for (var s = footerLink.FooterLinks.Count - 1; s >= 0; s--)
                                     {
                                         var childFooterLink = footerLink.FooterLinks[s];
-                                        newParentNode.Children.Add(new NavigationNodeCreationInformation()
+                                        var newChildNode = newParentNode.Children.Add(new NavigationNodeCreationInformation()
                                         {
                                             Url = parser.ParseString(childFooterLink.Url),
                                             Title = parser.ParseString(childFooterLink.DisplayName)
                                         });
-                                    }
+
+                                        if (childFooterLink.DisplayName.ContainsResourceToken())
+                                        {
+                                            web.Context.ExecuteQueryRetry();
+                                            newChildNode.LocalizeNavigationNode(web, childFooterLink.DisplayName, parser, scope);
+                                        }
+                                    }                                    
                                 }
                             }
                         }


### PR DESCRIPTION
Changes:
- Call LocalizeNavigationNode for each child node in footer. Old version only handles localization on each top node.