### PR TITLE
Additional changes for fix #498

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
@@ -73,7 +73,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     return parser;
                 }
 
-                web.EnsureProperties(w => w.Url);
+                web.EnsureProperties(w => w.HeaderLayout);
 
                 switch (template.Header.Layout)
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
@@ -17,13 +17,15 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         public override ProvisioningTemplate ExtractObjects(Web web, ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-            using (var scope = new PnPMonitoredScope(this.Name))
+            using (new PnPMonitoredScope(this.Name))
             {
                 web.EnsureProperties(w => w.HeaderEmphasis, w => w.HeaderLayout, w => w.MegaMenuEnabled);
+
                 var header = new SiteHeader
                 {
                     MenuStyle = web.MegaMenuEnabled ? SiteHeaderMenuStyle.MegaMenu : SiteHeaderMenuStyle.Cascading
                 };
+
                 switch (web.HeaderLayout)
                 {
                     case HeaderLayoutType.Compact:
@@ -31,17 +33,19 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             header.Layout = SiteHeaderLayout.Compact;
                             break;
                         }
+
                     case HeaderLayoutType.Minimal:
                         {
                             header.Layout = SiteHeaderLayout.Minimal;
                             break;
                         }
+
                     case HeaderLayoutType.Extended:
                         {
                             header.Layout = SiteHeaderLayout.Extended;
                             break;
                         }
-                    case HeaderLayoutType.Standard:
+
                     default:
                         {
                             header.Layout = SiteHeaderLayout.Standard;
@@ -49,51 +53,68 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         }
                 }
 
-                if (Enum.TryParse<Emphasis>(web.HeaderEmphasis.ToString(), out Emphasis backgroundEmphasis))
+                if (Enum.TryParse(web.HeaderEmphasis.ToString(), out Emphasis backgroundEmphasis))
                 {
                     header.BackgroundEmphasis = backgroundEmphasis;
                 }
 
                 template.Header = header;
             }
+
             return template;
         }
 
         public override TokenParser ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
         {
-            using (var scope = new PnPMonitoredScope(this.Name))
+            using (new PnPMonitoredScope(this.Name))
             {
+                if (template.Header == null)
+                {
+                    return parser;
+                }
+
                 web.EnsureProperties(w => w.Url);
 
-                if (template.Header != null)
+                switch (template.Header.Layout)
                 {
-                    switch (template.Header.Layout)
-                    {
-                        case SiteHeaderLayout.Compact:
-                            {
-                                web.HeaderLayout = HeaderLayoutType.Compact;
-                                break;
-                            }
-                        case SiteHeaderLayout.Standard:
-                            {
-                                web.HeaderLayout = HeaderLayoutType.Standard;
-                                break;
-                            }
-                    }
-                    web.HeaderEmphasis = (SPVariantThemeType)Enum.Parse(typeof(SPVariantThemeType), template.Header.BackgroundEmphasis.ToString());
-                    web.MegaMenuEnabled = template.Header.MenuStyle == SiteHeaderMenuStyle.MegaMenu;
+                    case SiteHeaderLayout.Compact:
+                        {
+                            web.HeaderLayout = HeaderLayoutType.Compact;
+                            break;
+                        }
 
-                    var jsonRequest = new
-                    {
-                        headerLayout = web.HeaderLayout,
-                        headerEmphasis = web.HeaderEmphasis,
-                        megaMenuEnabled = web.MegaMenuEnabled,
-                    };
+                    case SiteHeaderLayout.Minimal:
+                        {
+                            web.HeaderLayout = HeaderLayoutType.Minimal;
+                            break;
+                        }
 
-                    web.ExecutePostAsync("/_api/web/SetChromeOptions", System.Text.Json.JsonSerializer.Serialize(jsonRequest)).GetAwaiter().GetResult();
+                    case SiteHeaderLayout.Extended:
+                        {
+                            web.HeaderLayout = HeaderLayoutType.Extended;
+                            break;
+                        }
 
+                    case SiteHeaderLayout.Standard:
+                        {
+                            web.HeaderLayout = HeaderLayoutType.Standard;
+                            break;
+                        }
                 }
+
+                web.HeaderEmphasis = (SPVariantThemeType)Enum.Parse(typeof(SPVariantThemeType), template.Header.BackgroundEmphasis.ToString());
+                web.MegaMenuEnabled = template.Header.MenuStyle == SiteHeaderMenuStyle.MegaMenu;
+
+                var jsonRequest = new
+                {
+                    headerLayout = web.HeaderLayout,
+                    headerEmphasis = web.HeaderEmphasis,
+                    megaMenuEnabled = web.MegaMenuEnabled,
+                };
+
+                web.ExecutePostAsync("/_api/web/SetChromeOptions", System.Text.Json.JsonSerializer.Serialize(jsonRequest)).GetAwaiter().GetResult();
             }
+
             return parser;
         }
 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteHeaderSettings.cs
@@ -73,7 +73,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     return parser;
                 }
 
-                web.EnsureProperties(w => w.HeaderLayout);
+                web.EnsureProperties(w => w.Url, w => w.HeaderLayout);
 
                 switch (template.Header.Layout)
                 {


### PR DESCRIPTION
The previously made changes for fix #498 were missing changes required for provisioning the header information.

Additional changes:

* Removed case for `HeaderLayoutType.Standard` in `ExtractObjects`,  because `default` already handles this.
* Removed `scope` variable, because it is not used.
* Removed the `Emphasis` type reference from `Enum.TryParse`, because  the `out` variable already specifies the type.
* `ProvisionObjects` now exits as soon as possible if no changes are required.
  * This also moves a possible server call for loading the web URL to a state, were this information would be required.
* Introduced some (single) blank lines to increase the readability of the code.