### PR TITLE
set ContextSettings Type to ClientContextType.PnPCoreSdk 

### DIFF
--- a/src/lib/PnP.Framework/PnPCoreSdk.cs
+++ b/src/lib/PnP.Framework/PnPCoreSdk.cs
@@ -130,6 +130,7 @@ namespace PnP.Framework
 
             var ctx = authManager.GetContext(pnpContext.Uri.ToString());
             var ctxSettings = ctx.GetContextSettings();
+            ctxSettings.Type = Utilities.Context.ClientContextType.PnPCoreSdk;
             ctxSettings.AuthenticationManager = authManager; //otherwise GetAccessToken would not work for example
             ctx.AddContextSettings(ctxSettings);
             return ctx;


### PR DESCRIPTION
when GetClientContext is called with a PnPContext in order to not reauthenticate when clone context