### PR TITLE
Fix Clear-PnPDefaultColumnValues not working with taxonomy fields

### DIFF
--- a/src/lib/PnP.Framework/Extensions/FieldAndContentTypeExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/FieldAndContentTypeExtensions.cs
@@ -859,13 +859,15 @@ namespace Microsoft.SharePoint.Client
                         terms.Add(term);
                     }
                 }
+
+                defaultColumnValue = new DefaultColumnTermValue()
+                {
+                    FieldInternalName = field.InternalName,
+                    FolderRelativePath = folderRelativePath,
+                };
+
                 if (terms.Any())
                 {
-                    defaultColumnValue = new DefaultColumnTermValue()
-                    {
-                        FieldInternalName = field.InternalName,
-                        FolderRelativePath = folderRelativePath,
-                    };
                     terms.ForEach(t => ((DefaultColumnTermValue)defaultColumnValue).Terms.Add(t));
                 }
             }

--- a/src/lib/PnP.Framework/Extensions/ListExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ListExtensions.cs
@@ -1993,23 +1993,26 @@ namespace Microsoft.SharePoint.Client
 
                 // Check if default values file is present
                 var formsFolder = list.RootFolder.Folders.FirstOrDefault(x => x.Name == "Forms");
-                var configFile = formsFolder.Files.GetByUrl(defaultValuesFileName);
-                clientContext.Load(configFile, c => c.Exists);
-                bool fileExists = false;
-                try
+                if (formsFolder != null)
                 {
-                    clientContext.ExecuteQueryRetry();
-                    fileExists = true;
-                }
-                catch
-                {
-                    // Do nothing here
-                }
+                    var configFile = formsFolder.Files.GetByUrl(defaultValuesFileName);
+                    clientContext.Load(configFile, c => c.Exists);
+                    bool fileExists = false;
+                    try
+                    {
+                        clientContext.ExecuteQueryRetry();
+                        fileExists = true;
+                    }
+                    catch
+                    {
+                        // Do nothing here
+                    }
 
-                if (fileExists)
-                {
-                    configFile.DeleteObject();
-                    clientContext.ExecuteQueryRetry();
+                    if (fileExists)
+                    {
+                        configFile.DeleteObject();
+                        clientContext.ExecuteQueryRetry();
+                    }
                 }
             }
         }

--- a/src/lib/PnP.Framework/Extensions/ListExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ListExtensions.cs
@@ -1656,7 +1656,9 @@ namespace Microsoft.SharePoint.Client
 
         private static void SetDefaultColumnValuesImplementation(this List list, IEnumerable<IDefaultColumnValue> columnValues)
         {
-            if (columnValues == null || !columnValues.Any()) return;
+            if (columnValues == null || !columnValues.Any())
+                list.ClearDefaultColumnValues();
+
             using (var clientContext = list.Context as ClientContext)
             {
                 try


### PR DESCRIPTION
Clear-PnPDefaultColumnValues currently throws a NullDereferenceException when invoked on taxonomy fields.
This PR fixes the exception caused by `GetDefaultColumnValueFromField()` returning null when an empty array is passed as argument (meaning "no default taxonomy values"), returning instead a `DefaultColumnTermValue` object with no terms in it,  and changes `SetDefaultColumnValuesImplementation` to clear any default column value if there are none left to be kept.

In addition to this I added a null check in ListExtensions.ClearDefaultColumnValues() as it was triggering a null exception when the folder "Forms" was not present (I didn't investigate further if this happens only in special cases, like modern lists just provisioned).

Fixes https://github.com/pnp/powershell/issues/1110 , https://github.com/MicrosoftDocs/OfficeDocs-SharePoint-PowerShell/issues/130 , https://github.com/pnp/PnP-PowerShell/issues/1978

Tests done:
1. Add a default taxonomy value, then remove it and expect no default values left
![image](https://user-images.githubusercontent.com/1153754/149594410-a5f93de2-8ac4-4390-a143-5bb474a16d1c.png)

2. Add a default taxonomy value and a default string value, then remove the taxonomy and expect the string value to still be there. Remove the string value too and expect no default values left
![image](https://user-images.githubusercontent.com/1153754/149594496-874e479b-e758-475d-8bdf-5b10e207b91c.png)

3. Apply a PnP Template with some lists and different column types