### PR TITLE
fix ProcessDataRow ignore html fields as empty even they are not

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -895,11 +895,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             }
             foreach (var fieldValue in filteredFieldValues)
             {
-                var value = item.FieldValuesAsText[fieldValue.Key];
-                var skip = extractionConfig.SkipEmptyFields && string.IsNullOrEmpty(value);
+                var value = item.FieldValuesAsText[fieldValue.Key];//FieldValuesAsText strips of html and returns empty string in case all info is in attributes like for canvascontrol in HostedAppsConfig
+                var skip = extractionConfig.SkipEmptyFields && item[fieldValue.Key]==null;
                 if (!skip)
                 {
-                    dataRow.Values.Add(fieldValue.Key, TokenizeValue(web, siteList.Fields.FirstOrDefault(f => f.InternalName == fieldValue.Key).TypeAsString, fieldValue, value));
+                    string parsedValue = TokenizeValue(web, siteList.Fields.FirstOrDefault(f => f.InternalName == fieldValue.Key).TypeAsString, fieldValue, value);
+                    if(!(extractionConfig.SkipEmptyFields && string.IsNullOrEmpty(parsedValue)))
+                        dataRow.Values.Add(fieldValue.Key, parsedValue);
                 }
             }
             if (queryConfig != null && queryConfig.IncludeAttachments && siteList.EnableAttachments && (bool)item["Attachments"])


### PR DESCRIPTION
The issue comes with new way of storing spfx config in HostedAppConfigs Field CanvasControl1 - since all data is in attributes the FieldValueAsText strips off all html and leaves a empty string which was skiped. This did result in a weird behavior as  old entries were still exported since there the instance id was still in html as text and therefore not empty but new ones were missed.