### PR TITLE
Calculated field should be created after other fields

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
@@ -17,7 +17,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 _fieldXmlDictionary[templateField] = schemaElement;
             }
             var type = (string)schemaElement.Attribute("Type");
-            if (type != "Lookup" && type != "LookupMulti")
+            if (type != "Lookup" && type != "LookupMulti" && type != "Calculated")
             {
                 return Step.ListAndStandardFields;
             }


### PR DESCRIPTION
Calculated field should be created after other fields, as with lookup column, to avoid the error "The formula refers to a column that does not exist"