### PR TITLE
Exporting/Provisioning _ModerationStatus for folders

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2182,7 +2182,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         currentFolder.Update();
                         parentFolder.Context.ExecuteQueryRetry();
                                                 
-                        //Set moderation status, doing in a diferent request, because SharePoint doesn't allow to update properties at the same time that other properties
+                        //Set moderation status, doing it in a different request, because SharePoint doesn't allow to update properties at the same time that other properties
                         if ((list.SiteList.EnableModeration) && (folder.Properties.Any(p => p.Key.Equals("_ModerationStatus"))))
                         {
                             var propertyValue = folder.Properties["_ModerationStatus"];

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -786,6 +786,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             {
                                 value = TokenizeValue(web, field.TypeAsString, fieldValue, fieldValuesAsText[field.InternalName]);
                             }
+                            
+                            //We process moderation status, ideally this shoud be managed with a new attribute in Folder, but it requires a new schema version
+                            if (fieldValue.Key.Equals("_ModerationStatus", StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                value = TokenizeValue(web, field.TypeAsString, fieldValue, fieldValuesAsText[field.InternalName]);
+                            }
 
                             if (fieldValue.Key.Equals("ContentTypeId", StringComparison.InvariantCultureIgnoreCase) || fieldValue.Key.Equals("Attachments", StringComparison.InvariantCultureIgnoreCase))
                             {


### PR DESCRIPTION
Currently when a document library has enable moderation activated and has approved folders, when exporting them and provisioning a new site from the template the folders keep pending.
Since there is no attribute on the PnP Schema to set that on the Folder, I've done a change to get _ModerationStatus as property only for Folders ( if it's set in the ViewFields export list configuration ) and also to support modify that field if present during the creation of the folder.