### PR TITLE
do not try to tokenize non Guid termsetids as they probaly already tokenized from List before files

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -109,8 +109,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             var termSetIdElement = element.XPathSelectElement("./Customization/ArrayOfProperty/Property[Name = 'TermSetId']/Value");
             if (termSetIdElement != null)
             {
-                Guid termSetId = Guid.Parse(termSetIdElement.Value);
-                if (termSetId != Guid.Empty)
+                Guid termSetId;
+                if (Guid.TryParse(termSetIdElement.Value, out termSetId) && termSetId != Guid.Empty)
                 {
                     Microsoft.SharePoint.Client.Taxonomy.TermSet termSet = store.GetTermSet(termSetId);
                     store.Context.ExecuteQueryRetry();


### PR DESCRIPTION
Issue came with Field MediaServiceImageTags which was already tokenized as {termsetid:System:Image Tags} on a Tenant with the new editable Image Tags feature rolled-out.