### PR TITLE
Adding token parsing of folder name before setting default field values

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -199,7 +199,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             var defaultFolderValues = new List<Entities.IDefaultColumnValue>();
                             foreach (var templateListFolder in listInfo.TemplateList.Folders)
                             {
-                                var folderName = templateListFolder.Name;
+                                var folderName = parser.ParseString(templateListFolder.Name);
                                 ProcessDefaultFolders(web, listInfo, templateListFolder, folderName, defaultFolderValues, parser);
                             }
                             listInfo.SiteList.SetDefaultColumnValues(defaultFolderValues, true);


### PR DESCRIPTION
Issue description: when using resources / localization in folder names (we are creating sites in different languages) setting default field values will not work as tokens are not parsed in folder names.
![image](https://user-images.githubusercontent.com/1370426/170252376-fae898fe-deb3-4e99-b6ea-75ec53a34b29.png)

This PR adds token parsing in folder names before setting default filed values.