### PR TITLE
Add ConfigureAwait(false) to AcquireTokenForClient

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -914,7 +914,7 @@ namespace PnP.Framework
                         }
                         catch
                         {
-                            authResult = await confidentialClientApplication.AcquireTokenForClient(scopes).ExecuteAsync(cancellationToken);
+                            authResult = await confidentialClientApplication.AcquireTokenForClient(scopes).ExecuteAsync(cancellationToken).ConfigureAwait(false);
                         }
                         if (authResult.AccessToken != null)
                         {


### PR DESCRIPTION
While migrating a daemon app I'm facing a deadlock on AcquireTokenForClient method, trying to retrive CSOM ClientContext.
Adding ConfigureAwait(false) solves the problem.