### PR TITLE
Change to not re-throw caught exception during provisioning

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -208,7 +208,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             CallWebHooks(hierarchy.Templates.FirstOrDefault(), sequenceTokenParser,
                                 ProvisioningTemplateWebhookKind.ProvisioningExceptionOccurred, handler.Name, ex);
-                            throw ex;
+                            throw;
                         }
                     }
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
This PR changes so that a caught exception during provisioning is not re-thrown which would cause the stack trace to be reset and it was much harder to troubleshoot where the exception originally occurred.