### PR TITLE
Fixed bug with not correct PnPContext from ClientContext

### DIFF
--- a/src/lib/PnP.Framework/PnPCoreSdk.cs
+++ b/src/lib/PnP.Framework/PnPCoreSdk.cs
@@ -52,7 +52,7 @@ namespace PnP.Framework
             if (ctxSettings!=null && ctxSettings.Type == Utilities.Context.ClientContextType.PnPCoreSdk && ctxSettings.AuthenticationManager!=null)
             {
                 var pnpContext = ctxSettings.AuthenticationManager.PnPCoreContext;
-                if (pnpContext != null)
+                if (pnpContext != null && pnpContext.Uri == ctxUri)
                 {
                     return pnpContext;
                 }


### PR DESCRIPTION
When i use the "await PnPCoreSdk.Instance.GetPnPContextAsync" with a clientcontext with as example the following url: "https://cosmos.sharepoint.com/sites/cosmos". Then the function returns a PnPContext with the sharepoint admin url ("https://cosmos-admin.sharepoint.com/").

Steps to reproduce
Create a client context with a site url.
Use the clientcontext to create a pnpcontext with the following function: "await PnPCoreSdk.Instance.GetPnPContextAsync"
2: try it with clientcontext.Web.Context

Create a client context with a site url.
Use the clientcontext.Web.Context to create a pnpcontext with the following function: "await PnPCoreSdk.Instance.GetPnPContextAsync(web.Context as ClientContext)"
Expected behavior
Expected behavior is a copy of the clientcontext to pnpcontext.

Environment details (development & target environment)
pnp.core: 1.6.0

Additional info
I get this problem in pnp.Framework when I'm trying to get a site template then we can't find any pages because the pnp.core is target to the sharepoint admin url

I also created a issue for this but that can be closed if my fix is correct:
https://github.com/pnp/pnpframework/issues/671