### PR TITLE
Fix for empty PnP:Templates in the xml

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Providers/Xml/XmlPnPSchemaBaseSerializer.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Xml/XmlPnPSchemaBaseSerializer.cs
@@ -514,7 +514,8 @@ namespace PnP.Framework.Provisioning.Providers.Xml
 
                 templates.SetValue(templatesItem, 0);
 
-                wrapper.SetPublicInstancePropertyValue("Templates", templates);
+                if (provisioningTemplates.Length > 0)
+                    wrapper.SetPublicInstancePropertyValue("Templates", templates);
 
                 // Serialize the XML-based object into a Stream
                 XmlSerializerNamespaces ns =


### PR DESCRIPTION
There is a bug in the template provisioning for hierarchy templates. When there is no "ProvisioningTemplate" then it still added a "pnp:Templates". And this will give a invalid xml error
Solution:
Check if there are any "ProvisioningTemplate"