### PR TITLE
Fix #1874 - add owners as members too for similar behavior

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -539,6 +539,7 @@ namespace PnP.Framework.Sites
 
             if (group != null && !string.IsNullOrEmpty(group.SiteUrl))
             {
+                Graph.UnifiedGroupsUtility.AddUnifiedGroupMembers(group.GroupId, siteCollectionCreationInformation.Owners, graphAccessToken);
                 // Try to configure the site/group classification, if any
                 if (!string.IsNullOrEmpty(siteCollectionCreationInformation.Classification))
                 {


### PR DESCRIPTION
Fix : https://github.com/pnp/powershell/issues/1874

By default, we are only adding Owners, but now with this fix, we will add them as members too so that we have similar behavior as when we use delegated permissions.

Have added them after group creation because of the 20 user limit in group creation request.