### PR TITLE
Avoid retrying when the hostname cannot be found

### DIFF
--- a/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
@@ -216,7 +216,13 @@ namespace Microsoft.SharePoint.Client
                             errorSb.AppendLine($"SocketErrorCode: {socketEx.SocketErrorCode}"); //ConnectionReset
                             errorSb.AppendLine($"Message: {socketEx.Message}"); //An existing connection was forcibly closed by the remote host
                             Log.Error(Constants.LOGGING_SOURCE, CoreResources.ClientContextExtensions_ExecuteQueryRetryException, errorSb.ToString());
-                            
+
+                            // Hostname unknown error code 11001 should not be retried
+                            if(socketEx.ErrorCode == 11001)
+                            {
+                                throw;
+                            }
+
                             //retry
                             wrapper = (ClientRequestWrapper)wex.Data["ClientRequest"];
                             retry = true;


### PR DESCRIPTION
Added a check that in case of a hostname not known SocketException, it doesn't blindly keep retrying. This can occur i.e. when you make a typo in the SPO hostname. It will silently and blindly keep trying to connect anyway. With this update, if the hostname doesn't exist, it will throw the exception up the stack to the caller gets notified of the problem.