### PR TITLE
Fix fileuniqueid and pageuniqueid export

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/FileUniqueIdToken.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/FileUniqueIdToken.cs
@@ -8,7 +8,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
     [TokenDefinitionDescription(
      Token = "{fileuniqueid:[siteRelativePath]}",
      Description = "Returns the unique id of a file which is being provisioned by the current template.",
-     Example = "{fileuniqueid:/sitepages/home.aspx}",
+     Example = "{fileuniqueid:sitepages/home.aspx}",
      Returns = "f2cd6d5b-1391-480e-a3dc-7f7f96137382")]
     internal class FileUniqueIdToken : TokenDefinition
     {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/FileUniqueIdTokenEncoded.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/FileUniqueIdTokenEncoded.cs
@@ -8,7 +8,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
     [TokenDefinitionDescription(
      Token = "{fileuniqueidencoded:[siteRelativePath]}",
      Description = "Returns the html safe encoded unique id of a file which is being provisioned by the current template.",
-     Example = "{fileuniqueid:/sitepages/home.aspx}",
+     Example = "{fileuniqueidencoded:sitepages/home.aspx}",
      Returns = "f2cd6d5b%2D1391%2D480e%2Da3dc%2D7f7f96137382")]
     internal class FileUniqueIdEncodedToken : TokenDefinition
     {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -583,7 +583,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                         {
                             // Try to see if this is a file
                             var file = web.GetFileById(uniqueId);
-                            web.Context.Load(file, f => f.Level, f => f.ServerRelativePath);
+                            web.Context.Load(file, f => f.Level, f => f.ServerRelativePath, f => f.ServerRelativeUrl);
                             web.Context.ExecuteQueryRetry();
 
                             // Item1 = was file added to the template


### PR DESCRIPTION
Fix fileuniqueidencoded, fileuniqueid, pageuniqueidencoded and pageuniqueid export, this can be seen when exporting an hero webpart, the images are missing due to failed replacement. I was updating the template manually when I noticed I could use tokens, as that is cumbersome, I just looked at the code and did this quick fix, so this will work in a future release. The example for fileuniqueid and fileuniqueidencoded was also wrong, the / is trimmed away like for pageuniqueid.