### PR TITLE
Converted Hierachy provisioning and extraction to async

### DIFF
--- a/src/lib/PnP.Framework/Extensions/TenantExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/TenantExtensions.cs
@@ -42,10 +42,34 @@ namespace Microsoft.SharePoint.Client
         /// <param name="tenantTemplate"></param>
         /// <param name="sequenceId"></param>
         /// <param name="configuration"></param>
+        public static async Task ApplyTenantTemplateAsync(this Tenant tenant, ProvisioningHierarchy tenantTemplate, string sequenceId, ApplyConfiguration configuration = null)
+        {
+            SiteToTemplateConversion engine = new SiteToTemplateConversion();
+            await engine.ApplyTenantTemplateAsync(tenant, tenantTemplate, sequenceId, configuration);
+        }
+
+        /// <summary>
+        /// Applies a template to a tenant
+        /// </summary>
+        /// <param name="tenant"></param>
+        /// <param name="tenantTemplate"></param>
+        /// <param name="sequenceId"></param>
+        /// <param name="configuration"></param>
         public static void ApplyTenantTemplate(this Tenant tenant, ProvisioningHierarchy tenantTemplate, string sequenceId, ApplyConfiguration configuration = null)
         {
             SiteToTemplateConversion engine = new SiteToTemplateConversion();
-            engine.ApplyTenantTemplate(tenant, tenantTemplate, sequenceId, configuration);
+            engine.ApplyTenantTemplateAsync(tenant, tenantTemplate, sequenceId, configuration).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Extracts a template from a tenant
+        /// </summary>
+        /// <param name="tenant"></param>
+        /// <param name="configuration"></param>
+        /// <returns></returns>
+        public static async Task<ProvisioningHierarchy> GetTenantTemplateAsync(this Tenant tenant, ExtractConfiguration configuration)
+        {
+            return await SiteToTemplateConversion.GetTenantTemplateAsync(tenant, configuration);
         }
 
         /// <summary>
@@ -56,7 +80,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns></returns>
         public static ProvisioningHierarchy GetTenantTemplate(this Tenant tenant, ExtractConfiguration configuration)
         {
-            return SiteToTemplateConversion.GetTenantTemplate(tenant, configuration);
+            return SiteToTemplateConversion.GetTenantTemplateAsync(tenant, configuration).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
@@ -1316,7 +1316,7 @@ namespace PnP.Framework.Graph
         /// <param name="retryCount">Number of times to retry the request in case of throttling</param>
         /// <param name="delay">Milliseconds to wait before retrying the request. The delay will be increased (doubled) every retry</param>
         /// <param name="azureEnvironment">Defines the Azure Cloud Deployment. This is used to determine the MS Graph EndPoint to call which differs per Azure Cloud deployments. Defaults to Production (graph.microsoft.com).</param>
-        public static void AddUnifiedGroupMembers(string groupId, string[] members, string accessToken, bool removeExistingMembers = false, int retryCount = 10, int delay = 500, AzureEnvironment azureEnvironment = AzureEnvironment.Production)
+        public static async Task AddUnifiedGroupMembers(string groupId, string[] members, string accessToken, bool removeExistingMembers = false, int retryCount = 10, int delay = 500, AzureEnvironment azureEnvironment = AzureEnvironment.Production)
         {
             if (String.IsNullOrEmpty(accessToken))
             {
@@ -1325,13 +1325,9 @@ namespace PnP.Framework.Graph
 
             try
             {
-                Task.Run(async () =>
-                {
-                    var graphClient = CreateGraphClient(accessToken, retryCount, delay, azureEnvironment);
+                var graphClient = CreateGraphClient(accessToken, retryCount, delay, azureEnvironment);
 
-                    await UpdateMembers(members, graphClient, groupId, removeExistingMembers);
-
-                }).GetAwaiter().GetResult();
+                await UpdateMembers(members, graphClient, groupId, removeExistingMembers);
             }
             catch (ServiceException ex)
             {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectAzureActiveDirectory.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectAzureActiveDirectory.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
 {
@@ -194,7 +195,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             return _willExtract.Value;
         }
 
-        public override TokenParser ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration)
+        public override async Task<TokenParser> ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration)
         {
             using (var scope = new PnPMonitoredScope(Name))
             {
@@ -231,7 +232,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             return parser;
         }
 
-        public override ProvisioningHierarchy ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
+        public override async Task<ProvisioningHierarchy> ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
         {
             // So far, no extraction
             return hierarchy;

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchyHandlerBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchyHandlerBase.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Online.SharePoint.TenantAdministration;
 using PnP.Framework.Provisioning.Model;
 using PnP.Framework.Provisioning.Model.Configuration;
+using System.Threading.Tasks;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
 {
@@ -26,9 +27,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         public abstract bool WillExtract(Tenant tenant, Model.ProvisioningHierarchy hierarchy, string sequenceId, ExtractConfiguration configuration);
 
-        public abstract TokenParser ProvisionObjects(Tenant tenant, Model.ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration);
+        public abstract Task<TokenParser> ProvisionObjects(Tenant tenant, Model.ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration);
 
-        public abstract ProvisioningHierarchy ExtractObjects(Tenant tenant, Model.ProvisioningHierarchy hierarchy, ExtractConfiguration configuration);
+        public abstract Task<ProvisioningHierarchy> ExtractObjects(Tenant tenant, Model.ProvisioningHierarchy hierarchy, ExtractConfiguration configuration);
 
         internal void WriteMessage(string message, ProvisioningMessageType messageType)
         {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceTermGroups.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceTermGroups.cs
@@ -8,6 +8,7 @@ using PnP.Framework.Provisioning.ObjectHandlers.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Term = Microsoft.SharePoint.Client.Taxonomy.Term;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
@@ -18,7 +19,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         public override string Name => "Term Groups";
 
-        public override TokenParser ProvisionObjects(Tenant tenant, Model.ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser,
+        public override async Task<TokenParser> ProvisionObjects(Tenant tenant, Model.ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser,
             ApplyConfiguration configuration)
         {
             using (var scope = new PnPMonitoredScope(this.Name))
@@ -74,7 +75,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             public TokenParser UpdatedParser { get; set; }
         }
 
-        public override ProvisioningHierarchy ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
+        public override async Task<ProvisioningHierarchy> ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
         {
             throw new NotImplementedException();
         }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchyTenant.cs
@@ -4,6 +4,7 @@ using PnP.Framework.Diagnostics;
 using PnP.Framework.Provisioning.Model;
 using PnP.Framework.Provisioning.Model.Configuration;
 using PnP.Framework.Provisioning.ObjectHandlers.Utilities;
+using System.Threading.Tasks;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
 {
@@ -14,12 +15,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             get { return "Tenant Settings"; }
         }
 
-        public override ProvisioningHierarchy ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
+        public override async Task<ProvisioningHierarchy> ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
         {
             return hierarchy;
         }
 
-        public override TokenParser ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration)
+        public override async Task<TokenParser> ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration)
         {
             using (var scope = new PnPMonitoredScope(this.Name))
             {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
 {
@@ -1588,7 +1589,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             return _willExtract.Value;
         }
 
-        public override TokenParser ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration)
+        public override async Task<TokenParser> ProvisionObjects(Tenant tenant, ProvisioningHierarchy hierarchy, string sequenceId, TokenParser parser, ApplyConfiguration configuration)
         {
             using (var scope = new PnPMonitoredScope(Name))
             {
@@ -1651,7 +1652,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             return parser;
         }
 
-        public override ProvisioningHierarchy ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
+        public override async Task<ProvisioningHierarchy> ExtractObjects(Tenant tenant, ProvisioningHierarchy hierarchy, ExtractConfiguration configuration)
         {
             using (var scope = new PnPMonitoredScope(Name))
             {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -7,6 +7,7 @@ using PnP.Framework.Provisioning.Model.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
 {
@@ -142,7 +143,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        internal void ApplyTenantTemplate(Tenant tenant, PnP.Framework.Provisioning.Model.ProvisioningHierarchy hierarchy, string sequenceId, ApplyConfiguration configuration)
+        internal async Task ApplyTenantTemplateAsync(Tenant tenant, PnP.Framework.Provisioning.Model.ProvisioningHierarchy hierarchy, string sequenceId, ApplyConfiguration configuration)
         {
             using (var scope = new PnPMonitoredScope(CoreResources.Provisioning_ObjectHandlers_Provisioning))
             {
@@ -202,7 +203,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         }
                         try
                         {
-                            sequenceTokenParser = handler.ProvisionObjects(tenant, hierarchy, sequenceId, sequenceTokenParser, configuration);
+                            sequenceTokenParser = await handler.ProvisionObjects(tenant, hierarchy, sequenceId, sequenceTokenParser, configuration);
                         }
                         catch (Exception ex)
                         {
@@ -219,7 +220,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             }
         }
 
-        internal static ProvisioningHierarchy GetTenantTemplate(Tenant tenant, ExtractConfiguration configuration = null)
+        internal static async Task<ProvisioningHierarchy> GetTenantTemplateAsync(Tenant tenant, ExtractConfiguration configuration = null)
         {
             if (configuration == null)
             {
@@ -260,7 +261,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             step++;
                         }
 
-                        tenantTemplate = handler.ExtractObjects(tenant, tenantTemplate, configuration);
+                        tenantTemplate = await handler.ExtractObjects(tenant, tenantTemplate, configuration);
                     }
                 }
 

--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -76,14 +76,14 @@ namespace PnP.Framework.Sites
         /// <param name="noWait">If specified the site will be created and the process will be finished asynchronously</param>
         /// <param name="graphAccessToken">An optional Access Token for Microsoft Graph to use for creeating the site within an App-Only context</param>
         /// <returns>ClientContext object for the created site collection</returns>
-        public static ClientContext Create(
+        public static async Task<ClientContext> Create(
             ClientContext clientContext,
             TeamSiteCollectionCreationInformation siteCollectionCreationInformation,
             int delayAfterCreation = 0,
             bool noWait = false,
             string graphAccessToken = null)
         {
-            var context = CreateAsync(clientContext, siteCollectionCreationInformation, delayAfterCreation, noWait: noWait, graphAccessToken: graphAccessToken).GetAwaiter().GetResult();
+            var context = await CreateAsync(clientContext, siteCollectionCreationInformation, delayAfterCreation, noWait: noWait, graphAccessToken: graphAccessToken);
             return context;
         }
 
@@ -539,7 +539,8 @@ namespace PnP.Framework.Sites
 
             if (group != null && !string.IsNullOrEmpty(group.SiteUrl))
             {
-                Graph.UnifiedGroupsUtility.AddUnifiedGroupMembers(group.GroupId, siteCollectionCreationInformation.Owners, graphAccessToken);
+                await Graph.UnifiedGroupsUtility.AddUnifiedGroupMembers(group.GroupId, siteCollectionCreationInformation.Owners, graphAccessToken);
+
                 // Try to configure the site/group classification, if any
                 if (!string.IsNullOrEmpty(siteCollectionCreationInformation.Classification))
                 {


### PR DESCRIPTION
I have converted the hierachy handlers to async and added a overload for ApplyTenantTemplate so that it is still posible to call it not async.

The reason why I did this is because if had problems with the creation of the graph client.

And also I'm not a big fan of the .GetAwaiter() function as it fakes the await and can give some problemes.