### PR TITLE
Added new team visibility option

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Model/Teams/BaseTeam.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/Teams/BaseTeam.cs
@@ -109,6 +109,10 @@ namespace PnP.Framework.Provisioning.Model.Teams
         /// <summary>
         /// Defines a Public Team
         /// </summary>
-        Public
+        Public,
+        /// <summary>
+        /// Defines a Class Team which is only available in education tenants
+        /// </summary>
+        HiddenMembership
     }
 }


### PR DESCRIPTION
Hi

M365 Education Tenant have an additional Team visibility option called HiddenMembership. This is used to prepare a Team for a class without the students having access. As soon the teacher is ready, the Team is activated and the students gain access.

The added Team Visibility Option HiddenMembership enables the possibility to create a ProvisioningTemplate of a Class Team.

Kind regards
Martin