### PR TITLE
Fix - Calculated field formula based on title instead of internal name

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectField.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectField.cs
@@ -280,7 +280,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     var fieldInternalNames = schemaElement.Descendants("FieldRef").Select(fr => fr.Attribute("Name").Value).Distinct();
                     foreach (var fieldInternalName in fieldInternalNames)
                     {
-                        formulastring = formulastring.Replace($"{fieldInternalName}", $"[{{fieldtitle:{fieldInternalName}}}]");
+                        var referencedField = fields.GetFieldByInternalName(fieldInternalName);
+                        formulastring = formulastring.Replace($"{fieldInternalName}", $"[{referencedField.Title}]");
                     }
                     var fieldRefParent = schemaElement.Descendants("FieldRefs");
                     fieldRefParent.Remove();


### PR DESCRIPTION
Fixes an issue reported on the PnP-Sites-Core repository ([here](https://github.com/pnp/PnP-Sites-Core/issues/2081) 

Reapplying a template containing a list with a calculated field throws  the exception "The formula refers to a column that does not exist. Check the formula for spelling mistakes or change the non-existing column to an existing column."