### PR TITLE
Allowing to create PnPContext from ClientContext with existing IPnPContextFactory

### DIFF
--- a/src/lib/PnP.Framework/PnPCoreSdk.cs
+++ b/src/lib/PnP.Framework/PnPCoreSdk.cs
@@ -42,8 +42,9 @@ namespace PnP.Framework
         /// Get's a PnPContext from a CSOM ClientContext
         /// </summary>
         /// <param name="context">CSOM ClientContext</param>
+        /// <param name="existingFactory">An existing factory to use for PnPContext creation, instead of an internal one.</param>
         /// <returns>The equivalent PnPContext</returns>
-        public async Task<PnPContext> GetPnPContextAsync(ClientContext context)
+        public async Task<PnPContext> GetPnPContextAsync(ClientContext context, IPnPContextFactory existingFactory = null)
         {
             Uri ctxUri = new Uri(context.Url);
 
@@ -61,12 +62,12 @@ namespace PnP.Framework
                     var iAuthProvider = ctxSettings.AuthenticationManager.PnPCoreAuthenticationProvider;
                     if (iAuthProvider != null)
                     {
-                        var factory0 = BuildContextFactory();
+                        var factory0 = existingFactory ?? BuildContextFactory();
                         return await factory0.CreateAsync(ctxUri, iAuthProvider).ConfigureAwait(false);
                     }
                 }
             }
-            var factory = BuildContextFactory();
+            var factory = existingFactory ?? BuildContextFactory();
             return await factory.CreateAsync(ctxUri, AuthenticationProviderFactory.GetAuthenticationProvider(context)).ConfigureAwait(false);
         }
 
@@ -74,10 +75,11 @@ namespace PnP.Framework
         /// Get's a PnPContext from a CSOM ClientContext
         /// </summary>
         /// <param name="context">CSOM ClientContext</param>
+        /// <param name="existingFactory">An existing factory to use for PnPContext creation, instead of an internal one.</param>
         /// <returns>The equivalent PnPContext</returns>
-        public PnPContext GetPnPContext(ClientContext context)
+        public PnPContext GetPnPContext(ClientContext context, IPnPContextFactory existingFactory = null)
         {
-            return GetPnPContextAsync(context).GetAwaiter().GetResult();
+            return GetPnPContextAsync(context, existingFactory).GetAwaiter().GetResult();
         }
 
         private IPnPContextFactory BuildContextFactory()


### PR DESCRIPTION
I have a scenario where I already have 1) a `ClientContext` and 2) an existing `IPnPContextFactory` with configured PnPCore settings, and I need a `PnPContext` created from that.

Currently there is a `GetPnPContext(Async)` method that allows to create a `PnPContext` from an existing `ClientContext`. But this uses an internal `IPnPContextFactory` that is not configured to use the settings I need. Thus I'd like to pass my own factory.

This pull request makes it possible to pass an already configured factory to be used for `PnPContext` creation.