### PR TITLE
Optimizing file upload speed by reducing the number of API calls

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectFiles.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Net;
 using File = Microsoft.SharePoint.Client.File;
 
@@ -57,6 +58,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 var currentFileIndex = 0;
                 var originalWeb = web; // Used to store and re-store context in case files are deployed to masterpage gallery
+                // PERFORMANCE NOTE: save already retrieved folder info to speed up uploading files to the same folders
+                var knownFolders = new Dictionary<string, Microsoft.SharePoint.Client.Folder>();
                 foreach (var file in filesToProcess)
                 {
                     file.Src = parser.ParseString(file.Src);
@@ -88,16 +91,27 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         continue;
                     }
 
-                    var folder = web.EnsureFolderPath(folderName);
+                    if (!knownFolders.TryGetValue(folderName, out var folder))
+                    {
+                        folder = web.EnsureFolderPath(folderName);
 
-                    folder.EnsureProperties(p => p.UniqueId, p => p.ServerRelativeUrl);
-                    parser.AddToken(new FileUniqueIdToken(web, folder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), folder.UniqueId));
-                    parser.AddToken(new FileUniqueIdEncodedToken(web, folder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), folder.UniqueId));
-                    
+                        folder.EnsureProperties(p => p.UniqueId, p => p.ServerRelativeUrl);
+                        parser.AddToken(new FileUniqueIdToken(web, folder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), folder.UniqueId));
+                        parser.AddToken(new FileUniqueIdEncodedToken(web, folder.ServerRelativeUrl.Substring(web.ServerRelativeUrl.Length).TrimStart("/".ToCharArray()), folder.UniqueId));
+                        knownFolders.Add(folderName, folder);
+                    }
+
                     var checkedOut = false;
 
                     var targetFile = folder.GetFile(template.Connector.GetFilenamePart(targetFileName));
 
+                    var additionalRetrievals = new List<Expression<Func<File, object>>>()
+                    {
+                        f => f.UniqueId,
+                        f => f.ServerRelativePath,
+                        f => f.ListItemAllFields.Id,
+                        f => f.Level
+                    };
                     if (targetFile != null)
                     {
                         if (file.Overwrite)
@@ -112,7 +126,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         }
                         else
                         {
-                            checkedOut = CheckOutIfNeeded(web, targetFile);
+                            checkedOut = CheckOutIfNeeded(web, targetFile, additionalRetrievals.ToArray());
                         }
                     }
                     else
@@ -130,19 +144,21 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             }
                         }
 
-                        checkedOut = CheckOutIfNeeded(web, targetFile);
+                        checkedOut = CheckOutIfNeeded(web, targetFile, additionalRetrievals.ToArray());
                     }
 
                     if (targetFile != null)
                     {
                         // Add the fileuniqueid tokens
-                        targetFile.EnsureProperties(p => p.UniqueId, p => p.ServerRelativePath);
+                        // PERFORMANCE NOTE: next call not needed; already loaded in CheckOutIfNeeded via additionalRetrievals (save API calls)
+                        // targetFile.EnsureProperties(p => p.UniqueId, p => p.ServerRelativePath);
 
                         // Add ListItemId token, given that a file can live outside of a library ensure this does not break provisioning
                         try
                         {
-                            web.Context.Load(targetFile, p => p.ListItemAllFields.Id);
-                            web.Context.ExecuteQueryRetry();
+                            // PERFORMANCE NOTE: next 2 calls not needed; already loaded in CheckOutIfNeeded via additionalRetrievals (save API calls)
+                            // web.Context.Load(targetFile, p => p.ListItemAllFields.Id);
+                            // web.Context.ExecuteQueryRetry();
                             if (targetFile.ListItemAllFields.ServerObjectIsNull.HasValue
                                 && !targetFile.ListItemAllFields.ServerObjectIsNull.Value)
                             {
@@ -210,12 +226,18 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             case Model.FileLevel.Published:
                                 {
-                                    targetFile.PublishFileToLevel(Microsoft.SharePoint.Client.FileLevel.Published);
+                                    if (targetFile.Level != Microsoft.SharePoint.Client.FileLevel.Published)
+                                    {
+                                        targetFile.PublishFileToLevel(Microsoft.SharePoint.Client.FileLevel.Published);
+                                    }
                                     break;
                                 }
                             case Model.FileLevel.Draft:
                                 {
-                                    targetFile.PublishFileToLevel(Microsoft.SharePoint.Client.FileLevel.Draft);
+                                    if (targetFile.Level != Microsoft.SharePoint.Client.FileLevel.Draft)
+                                    {
+                                        targetFile.PublishFileToLevel(Microsoft.SharePoint.Client.FileLevel.Draft);
+                                    }
                                     break;
                                 }
                             default:
@@ -244,12 +266,19 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             return parser;
         }
 
-        private static bool CheckOutIfNeeded(Web web, File targetFile)
+        private static bool CheckOutIfNeeded(Web web, File targetFile, params Expression<Func<File, object>>[] additionalRetrievals)
         {
             var checkedOut = false;
             try
             {
-                web.Context.Load(targetFile, f => f.CheckOutType, f => f.CheckedOutByUser, f => f.ListItemAllFields.ParentList.ForceCheckout);
+                var retrievals = new List<Expression<Func<File, object>>>
+                {
+                    f => f.CheckOutType,
+                    f => f.CheckedOutByUser,
+                    f => f.ListItemAllFields.ParentList.ForceCheckout
+                };
+                retrievals.AddRange(additionalRetrievals);
+                web.Context.Load(targetFile, retrievals.ToArray());
                 web.Context.ExecuteQueryRetry();
 
                 if (targetFile.ListItemAllFields.ServerObjectIsNull.HasValue


### PR DESCRIPTION
This contains the following parts:

1. caching folders that have already been loaded
2. bundling some property requests into one call
3. skipping PublishFileToLevel if the level is already met

This speeds up uploading of files if they go to the same folder. I'm uploading dozens, sometimes hundreds of file to the same folder. This used to take about 1,5-2 seconds per file. With those changes it's down to 0,75-1 second. (Rough estimate by looking at the console timestamps.) So this is now ~twice as fast.

But I'm creating this pull request as draft because I'm not entirely sure point 3 from the list is correct (this is about `PublishFileToLevel`). It looks correct but I don't know if this causes side effects to disappear that are actually needed somewhere. Maybe somebody can confirm that it is ok to check the existing level before trying to adjust it.