### PR TITLE
Add support to exporting renamed Title columns to a PnP template

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2759,7 +2759,6 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     {
                         if (field.InternalName == "Editor"
                             || field.InternalName == "Author"
-                            || field.InternalName == "Title"
                             || field.InternalName == "ID"
                             || field.InternalName == "Created"
                             || field.InternalName == "Modified"


### PR DESCRIPTION
Add support to exporting renamed Title columns to a PnP template by not excluding the field when generating a template.
The Title will be included as a FieldRef like below
```xml
<pnp:FieldRefs>
    <pnp:FieldRef ID="fa564e0f-0c70-4ab9-b863-0177e6ddd247" Name="Title" Required="true" DisplayName="Renamed title" />
</pnp:FieldRefs>
```

The field changes are already applied by the provisioning engine so no changes are required there.

I have found some old discussions about this change with different opinions. I hope it will be considered as a good addition.