### PR TITLE
Fix for infinite loop in Replacing Tokens when property values contain the Regex special char "$"

### DIFF
--- a/src/lib/PnP.Framework/Modernization/Transform/TokenParser.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/TokenParser.cs
@@ -41,7 +41,7 @@ namespace PnP.Framework.Modernization.Transform
                         {
                             // $0 in the replacement value is replaced by the input...need to escape it first to avoid getting into a recursive loop
                             // See https://stackoverflow.com/questions/41227351/trouble-with-0-in-regex-replace-c-sharp/41229868#41229868
-                            input = regex.Replace(input, property.Value.Replace("$0", "$$0"));
+                            input = regex.Replace(input, property.Value.Replace("$", "$$"));
                         }
                     }
                 }


### PR DESCRIPTION
The current implementation only escapes property values containing "$0" and will not escape other Regex $ expressions (e.g. "$", "$1", "$2").
These unescaped Regex $ expressions will be replaced with the whole match value and cause an infinite loop.

Doing property.Value.Replace("$", "$$") ensures all $ chars are properly escaped from the property value.

E.g.
property.Value = _"with a market value estimated to be worth **$** 50 billion by 2025"_ will be replaced by _"with a market value estimated to be worth **with a market value estimated to be worth **$** 50 billion by 2025** 50 billion by 2025"_