### PR TITLE
Fix for creating private channels

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -1040,7 +1040,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 displayName = parser.ParseString(channel.DisplayName),
                 isFavoriteByDefault = channel.Private ? false : channel.IsFavoriteByDefault,
                 membershipType = channel.Private ? "private" : "standard",
-                moderationSettings = new Dictionary<string, object>{
+                moderationSettings = channel.Private ? null : new Dictionary<string, object>{
                     { "userNewMessageRestriction", channel.UserNewMessageRestriction },
                     { "replyRestriction", channel.ReplyRestriction },
                     { "allowNewMessageFromBots", channel.AllowNewMessageFromBots },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?
A fix for a Bad Request error that occurs when creating private channels. This issue was introduced with the introduction of channel moderation settings since these are not supported for private channels.