### PR TITLE
fix LocalizationToken.GetReplaceValue: fallback to old logic

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/LocalizationToken.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/LocalizationToken.cs
@@ -37,7 +37,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
                     _resourceEntries.FirstOrDefault(r => r.LCID == _defaultLCID) :
                     _resourceEntries.First();
 
-                return defaultEntry.Value;
+                if (defaultEntry != null)
+                    return defaultEntry.Value;
+                else
+                    return _resourceEntries.First().Value; //fallback to old logic as for me _defaultLCID has always a Value i.e. 0 or the correct LCID
             }
 
         }


### PR DESCRIPTION
fallback to old logic as for me _defaultLCID has always a Value i.e. 0 or the correct LCID and will throw a error when defaultEntry is null because of the way resources are loaded. You can see first 2 have only one ResourceEntries in specific language and last one has 2 Entries. In case of a EN Default site the second LocalizationToken would fail to load - therefore the fallback.

![Screenshot_20221101_044323](https://user-images.githubusercontent.com/31336529/199428969-87c24090-3e17-4fed-aeb0-2adbe1937be5.png)
