### PR TITLE
Fix: Failed to resolve termsetid token

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHandlerBase.cs
@@ -117,7 +117,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                     if (!termSet.ServerObjectIsNull())
                     {
-                        termSet.EnsureProperties(ts => ts.Name, ts => ts.Group);
+                        termSet.EnsureProperties(ts => ts.Name, ts => ts.Group.Name, ts => ts.Group.IsSiteCollectionGroup);
 
                         termSetIdElement.Value = String.Format("{{termsetid:{0}:{1}}}", termSet.Group.IsSiteCollectionGroup ? "{sitecollectiontermgroupname}" : termSet.Group.Name, termSet.Name);
                     }


### PR DESCRIPTION
Failed to resolve termsetid token because IsSiteCollectionGroup was not initialized. 
This is kind of strange since the code was not changed. Therefore, it would think it needs to be a change in CSOM or Backend which leads to that issue. 