### PR TITLE
Fix for the UpdateListItem() in order to load respective properties for the list

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -115,7 +115,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                             }
                                             else
                                             {
-                                                listitem = existingItems[0];
+                                                listitem = existingItems.FirstOrDefault();
+                                                list.Context.Load(listitem);
+                                                list.Context.ExecuteQueryRetry();
                                                 processItem = true;
                                             }
                                         }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -268,6 +268,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             var context = item.Context as ClientContext;
             var list = item.ParentList;
             context.Web.EnsureProperty(w => w.Url);
+            context.Load(list, listProperty => listProperty.BaseType, listProperty => listProperty.RootFolder);
+            context.ExecuteQueryRetry();
 
             bool isDocLib = list.EnsureProperty(l => l.BaseType) == BaseType.DocumentLibrary;
             bool isPagesLib = list.EnsureProperty(l => l.RootFolder).Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);


### PR DESCRIPTION
Fix in reference to Bug#807.

Code contains update to load respective list object properties required for the UpdateListItem().
Also includes minor changes in "ObjectListInstanceDataRows.cs" file to properly load existing list item and ensure null is defined if not found.