### PR TITLE
Fix ViewTypeKind property being ignored when provisioning views

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -764,6 +764,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 var viewInnerXml = reader.ReadInnerXml();
 
                 var createdView = createdList.Views.Add(viewCI);
+                createdList.Update();
+                web.Context.ExecuteQueryRetry();
+
+                // Edit the view settings after creating it to avoid issues with some creation properties being ignored, for example ViewTypeKind
                 createdView.ListViewXml = viewInnerXml;
                 if (hidden) createdView.Hidden = hidden;
                 createdView.Update();


### PR DESCRIPTION
Fix ViewTypeKind property being ignored by SPO when provisioning a new view and updating ListViewXml property during the same ExecuteQueryRetry() call. All views would have ViewType set to HTML before.

The code in this PR first creates the view, calls ExecuteQueryRetry(), then updates the ListViewXml property, then calls ExecuteQueryRetry(). This seems to be needed by serverside behavior of SPO, as ViewCreationInformation is filled with the same information in both cases.

## Tests
The test was done with a view created from SPO List Settings with "Datasheet View" as base view and then exported with Get-PnPSiteTemplate. The xml template has these attributes:
```xml
<View Name="{221F9B40-A0A0-40AE-9AF6-8C109AD3C6B0}" Type="GRID" Personal="TRUE" DisplayName="Grid view" Url="{site}/Lists/TestList/PersonalViews.aspx" Level="1" BaseViewID="1" ContentTypeID="0x" ImageUrl="/_layouts/15/images/generic.png?rev=47">
```
Notice how the view provisioned before the fix has ViewType set to HTML and ListViewXml shows Type="HTML", even if the template has GRID
![image](https://user-images.githubusercontent.com/1153754/207669032-2ec29541-5d38-4c85-8a81-eb9b8a4684d7.png)

This is how the view looked on SPO, not grid view. A custom sorting by ID was added to test a different case than the standard view one:
![image](https://user-images.githubusercontent.com/1153754/207669722-31db3fda-3b14-4c0b-ba02-61616ddfaeb1.png)


This is the same view created using the same template after applying the fix from this PR. Notice how ViewType now is set to GRID and ListViewXml has Type="GRID":
![image](https://user-images.githubusercontent.com/1153754/207669976-710edce8-b1ad-40c0-b0a8-3b3d321e3b33.png)

SPO kept the same sorting by ID and the view is a grid view:
![image](https://user-images.githubusercontent.com/1153754/207670088-e83bb6c4-0e38-4569-9d5a-41c11e5c5036.png)



In an attempt to test it a bit deeper I created a few views, exported them as pnp template, deleted the list and re-applied the template.
Case with default "All items" plus a new custom field "Category":
![image](https://user-images.githubusercontent.com/1153754/207670407-f7d6ac25-e28b-4144-8131-72d16d8017d0.png)

Case grouping by custom field "Category", sorted by ID descending:
![image](https://user-images.githubusercontent.com/1153754/207670595-39c74f8c-2d07-4ba2-add6-007fd9b8fe8e.png)

Case filtering by custom field "Category" set to "Choice 2":
![image](https://user-images.githubusercontent.com/1153754/207670711-5c539ba9-133e-434f-9e46-8eaca5946c22.png)

Case with Grid view:
![image](https://user-images.githubusercontent.com/1153754/207670809-96c92a84-5e8b-4f40-9757-6f55457921c0.png)

Template used for the test cases:
[views.zip](https://github.com/pnp/pnpframework/files/10230443/views.zip)
