### PR TITLE
Chars ' and . are allowed in alias and urls

### DIFF
--- a/src/lib/PnP.Framework/Utilities/UrlUtility.cs
+++ b/src/lib/PnP.Framework/Utilities/UrlUtility.cs
@@ -221,7 +221,7 @@ namespace PnP.Framework.Utilities
 
         public static string RemoveUnallowedCharacters(string str)
         {
-            const string unallowedCharacters = "[&,!@;:#¤`´~¨='%<>/\\\\\"\\.\\$\\*\\^\\+\\|\\{\\}\\[\\]\\(\\)\\?\\s]";
+            const string unallowedCharacters = "[&,!@;:#¤`´~¨=%<>/\\\\\"\\$\\*\\^\\+\\|\\{\\}\\[\\]\\(\\)\\?\\s]";
             var regex = new Regex(unallowedCharacters);
             return regex.Replace(str, "");
         }


### PR DESCRIPTION
Right now when creating a O365 group, the characters . and ' are allowed for the alias and Url.
![image](https://user-images.githubusercontent.com/8925463/218114448-9544b1a5-8b84-49cb-8fac-94b2caf7f223.png)

Removing those characters from the expression to avoid replace them with empty char.
That way we can apply templates to a site with this URL
https://*********.sharepoint.com/sites/o'really-I.T

Right now, instead of applying templates to it, the solution is creating a new group/site with the URL
https://*********.sharepoint.com/sites/oreally-IT