### PR TITLE
Skip setting DefaultColumnValues if there are none specified in the provisioning template

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -219,7 +219,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                 var folderName = parser.ParseString(templateListFolder.Name);
                                 ProcessDefaultFolders(web, listInfo, templateListFolder, folderName, defaultFolderValues, parser);
                             }
-                            listInfo.SiteList.SetDefaultColumnValues(defaultFolderValues, true);
+
+                            if (defaultFolderValues.Any())
+                                listInfo.SiteList.SetDefaultColumnValues(defaultFolderValues, true);
                         }
 
                         #endregion Column default values


### PR DESCRIPTION
Skip setting DefaultColumnValues if there are none specified in the provisioning template.
This avoids adding an unused "LocationBasedMetadataDefaultsReceiver ItemAdded" event receiver (that is currently causing issues on some tenants).