### PR TITLE
Returning character ' as invalid

### DIFF
--- a/src/lib/PnP.Framework/Utilities/UrlUtility.cs
+++ b/src/lib/PnP.Framework/Utilities/UrlUtility.cs
@@ -221,7 +221,7 @@ namespace PnP.Framework.Utilities
 
         public static string RemoveUnallowedCharacters(string str)
         {
-            const string unallowedCharacters = "[&,!@;:#¤`´~¨=%<>/\\\\\"\\$\\*\\^\\+\\|\\{\\}\\[\\]\\(\\)\\?\\s]";
+            const string unallowedCharacters = "[&,!@;:#¤`´~¨='%<>/\\\\\"\\$\\*\\^\\+\\|\\{\\}\\[\\]\\(\\)\\?\\s]";
             var regex = new Regex(unallowedCharacters);
             return regex.Replace(str, "");
         }


### PR DESCRIPTION
Returning back the character ' because since it's valid for URLs, a later call to SharePoint _api/SP.Directory.DirectorySession/Group(alias=....) is failing