### PR TITLE
Set Webpart Title and Description during page creation

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -724,6 +724,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                                 myWebPart.InstanceId = instanceId;
                                             }
                                         }
+                                        if (json["title"] != null && json["title"].Type != JTokenType.Null)
+                                        {
+                                            myWebPart.Title = parser.ParseString(json["title"].Value<string>());
+                                        }
+                                        if (json["description"] != null && json["description"].Type != JTokenType.Null)
+                                        {
+                                            myWebPart.Description = parser.ParseString(json["description"].Value<string>());
+                                        }
                                     }
 
                                     // Reduce column number by 1 due 0 start indexing
@@ -788,6 +796,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                             {
                                                 myWebPart.InstanceId = instanceId;
                                             }
+                                        }
+                                        if (json["title"] != null && json["title"].Type != JTokenType.Null)
+                                        {
+                                            myWebPart.Title = parser.ParseString(json["title"].Value<string>());
+                                        }
+                                        if (json["description"] != null && json["description"].Type != JTokenType.Null)
+                                        {
+                                            myWebPart.Description = parser.ParseString(json["description"].Value<string>());
                                         }
                                         if (json["id"] != null && json["id"].Type != JTokenType.Null)
                                         {


### PR DESCRIPTION
Set webpart title and description properties when creating a page that contains webparts. Having a webpart with different preconfigured entries, when adding it manually from the UI, it was setting properly the title to the webpart. 

However, when adding the same webpart in a ClientSidePage with PnP, the title set into the webpart was the title of the main configuration of the webpart, not the preconfigured one....

![image](https://user-images.githubusercontent.com/8925463/229432684-70091c7a-f4e3-417d-8ca8-8dedb6e0a255.png)

First control was the one created during the provisioning of the page, the second one, was the added manually.
![image](https://user-images.githubusercontent.com/8925463/229433445-6411d97c-8f9d-4cfd-ae6f-2a103561c965.png)

After the change, both will be the same.