### PR TITLE
Adding support for content types hidden in the export at list level.

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2632,7 +2632,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             foreach (var ct in siteList.ContentTypes)
             {
                 web.Context.Load(ct, c => c.Parent);
+                web.Context.Load(siteList.RootFolder, rf => rf.UniqueContentTypeOrder);
                 web.Context.ExecuteQueryRetry();
+
+                bool ctypeHidden = siteList.RootFolder.UniqueContentTypeOrder != null
+                    ? siteList.RootFolder.UniqueContentTypeOrder.FirstOrDefault(c => c.StringValue.Equals(ct.Id.StringValue, StringComparison.OrdinalIgnoreCase)) == null
+                    : false;
 
                 if (ct.Parent != null)
                 {
@@ -2643,14 +2648,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     // Exclude System Content Type to prevent getting exception during import
                     if (!ct.Parent.StringId.Equals(BuiltInContentTypeId.System))
                     {
-                        list.ContentTypeBindings.Add(new ContentTypeBinding { ContentTypeId = ct.Parent.StringId, Default = count == 0 });
+                        list.ContentTypeBindings.Add(new ContentTypeBinding { ContentTypeId = ct.Parent.StringId, Default = count == 0, Hidden = ctypeHidden });
                     }
 
                     //}
                 }
                 else
                 {
-                    list.ContentTypeBindings.Add(new ContentTypeBinding { ContentTypeId = ct.StringId, Default = count == 0 });
+                    list.ContentTypeBindings.Add(new ContentTypeBinding { ContentTypeId = ct.StringId, Default = count == 0, Hidden = ctypeHidden });
                 }
 
                 web.Context.Load(ct.FieldLinks);


### PR DESCRIPTION
Basically in the export of site to a PnP template the content types that were hidden at list level were not coming in the template with the attribute Hidden=True. So the fix is to support this, so if there is a content type not visible at list level if will be returned in the template with Hidden=True

