### PR TITLE
Fix "The request was already sent" error when getting app metadata (using AppManager)

### DIFF
--- a/src/lib/PnP.Framework/ALM/AppManager.cs
+++ b/src/lib/PnP.Framework/ALM/AppManager.cs
@@ -919,14 +919,14 @@ namespace PnP.Framework.ALM
 
             var metadataRequestUrl = $"{context.Web.Url}/_api/web/{(scope == AppCatalogScope.Tenant ? "tenant" : "sitecollection")}appcatalog/AvailableApps/GetById('{id}')";
 
-            using (var metadataRequest = new HttpRequestMessage(HttpMethod.Get, metadataRequestUrl))
+            while (returnValue == null && retryCount < 5)
             {
-                metadataRequest.Headers.Add("accept", "application/json;odata=nometadata");
-
-                await PnPHttpClient.AuthenticateRequestAsync(metadataRequest, context).ConfigureAwait(false);
-
-                while (returnValue == null && retryCount < 5)
+                using (var metadataRequest = new HttpRequestMessage(HttpMethod.Get, metadataRequestUrl))
                 {
+                    metadataRequest.Headers.Add("accept", "application/json;odata=nometadata");
+    
+                    await PnPHttpClient.AuthenticateRequestAsync(metadataRequest, context).ConfigureAwait(false);
+                
                     // Perform actual post operation
                     HttpResponseMessage metadataResponse = await httpClient.SendAsync(metadataRequest, new System.Threading.CancellationToken());
 
@@ -951,8 +951,8 @@ namespace PnP.Framework.ALM
                         await Task.Delay(waitTime * 1000); // wait 10 seconds
                     }
                 }
-                return returnValue;
-            }
+            }  
+            return returnValue;
         }
         #endregion
     }


### PR DESCRIPTION
When getting app metadata after an app has been added, if  `metadataResponse.StatusCode == HttpStatusCode.NotFound` then it will retry the request but without creating a new HttpRequestMessage. This causes the following error "System.InvalidOperation: The request was already sent. Cannot send the same request multiple times".  

In this fix I included the creation of the HttpRequestMessage inside the while loop so that each time a retry is made, it creates a new HttpRequestMessage.