### PR TITLE
Added support for setting TimeZoneId when creating a new site collection

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -143,6 +143,10 @@ namespace PnP.Framework.Sites
             {
                 payload.Add("PreferredDataLocation", siteCollectionCreationInformation.PreferredDataLocation.Value.ToString());
             }
+            if (siteCollectionCreationInformation.TimeZoneId.HasValue)
+            {
+                payload.Add("TimeZoneId", siteCollectionCreationInformation.TimeZoneId.Value);
+            }
 
             return await CreateAsync(clientContext, siteCollectionCreationInformation.Owner, payload, delayAfterCreation, noWait: noWait);
         }
@@ -191,6 +195,10 @@ namespace PnP.Framework.Sites
             {
                 payload.Add("SensitivityLabel", sensitivityLabelId);
                 payload["Classification"] = siteCollectionCreationInformation.SensitivityLabel;
+            }
+            if (siteCollectionCreationInformation.TimeZoneId.HasValue)
+            {
+                payload.Add("TimeZoneId", siteCollectionCreationInformation.TimeZoneId.Value);
             }
             return await CreateAsync(
                 clientContext,

--- a/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollectionCreationInformation.cs
@@ -157,6 +157,11 @@ namespace PnP.Framework.Sites
         /// </summary>
         public Enums.Office365Geography? PreferredDataLocation { get; set; }
 
+        /// <summary>
+        /// The time zone to use for the site.
+        /// </summary>
+        public int? TimeZoneId { get; set; }
+
         public SiteCreationInformation()
         {
         }


### PR DESCRIPTION
The Sharepoint REST API supports setting the TimeZoneId and now PnP does too

EDIT: This issue seems related #511