### PR TITLE
fix(provisioning): non-taxonomy default folder values cause error

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -282,8 +282,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 if (!string.IsNullOrEmpty(fieldValue))
                 {
                     var field = listInfo.SiteList.Fields.GetByInternalNameOrTitle(fieldName);
-                    var defaultValue = field.GetDefaultColumnValueFromField((ClientContext)web.Context, folderName, TermIdsToProcess(fieldValue).ToArray());
-                    defaultFolderValues.Add(defaultValue);
+                    
+                    var value = field.TypeAsString is "TaxonomyFieldType" or "TaxonomyFieldTypeMulti"
+                        ? TermIdsToProcess(fieldValue).ToArray()
+                        : new string[] { fieldValue };
+                    
+                        var defaultValue = field.GetDefaultColumnValueFromField((ClientContext)web.Context, folderName, value);
+                        defaultFolderValues.Add(defaultValue);
                 }
             }
             foreach (var folder in templateListFolder.Folders)


### PR DESCRIPTION
This fixes a bug in the provisioning engine where default folder values would crash for any field type other than metadata.