### PR TITLE
Added Stream and XML option to load Tenant template

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Providers/Json/JsonTemplateProvider.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Json/JsonTemplateProvider.cs
@@ -57,6 +57,15 @@ namespace PnP.Framework.Provisioning.Providers.Json
 
             return (result);
         }
+        public override List<ProvisioningHierarchy> GetHierarchies()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ProvisioningHierarchy GetHierarchy(Stream stream)
+        {
+            throw new NotImplementedException();
+        }
 
         public override ProvisioningHierarchy GetHierarchy(string uri)
         {

--- a/src/lib/PnP.Framework/Provisioning/Providers/Markdown/MarkdownTemplateProvider.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Markdown/MarkdownTemplateProvider.cs
@@ -58,6 +58,16 @@ namespace PnP.Framework.Provisioning.Providers.Markdown
             return (result);
         }
 
+        public override List<ProvisioningHierarchy> GetHierarchies()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ProvisioningHierarchy GetHierarchy(Stream stream)
+        {
+            throw new NotImplementedException();
+        }
+
         public override ProvisioningHierarchy GetHierarchy(string uri)
         {
             throw new NotImplementedException();

--- a/src/lib/PnP.Framework/Provisioning/Providers/TemplateProviderBase.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/TemplateProviderBase.cs
@@ -119,11 +119,24 @@ namespace PnP.Framework.Provisioning.Providers
         public abstract List<ProvisioningTemplate> GetTemplates(ITemplateFormatter formatter);
 
         /// <summary>
+        /// Gets list of ProvisioningHierarchies
+        /// </summary>
+        /// <returns>Returns collection of ProvisioningHierarchies</returns>
+        public abstract List<ProvisioningHierarchy> GetHierarchies();
+
+        /// <summary>
         /// Gets ProvisioningHierarchy
         /// </summary>
         /// <param name="uri">The source uri</param>
         /// <returns>Returns a ProvisioningHierarchy</returns>
         public abstract ProvisioningHierarchy GetHierarchy(string uri);
+
+        /// <summary>
+        /// Gets ProvisioningHierarchy
+        /// </summary>
+        /// <param name="stream">The source as a stream</param>
+        /// <returns>Returns a ProvisioningHierarchy</returns>
+        public abstract ProvisioningHierarchy GetHierarchy(Stream stream);
 
         /// <summary>
         /// Gets ProvisioningTemplate


### PR DESCRIPTION
Added options to load a tenant template based on a stream and an XML string, like we already had for the site templates. Will be used by PnP PowerShell.