### PR TITLE
Implement adding labels to terms

### DIFF
--- a/src/lib/PnP.Framework/Extensions/TaxonomyExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/TaxonomyExtensions.cs
@@ -1609,28 +1609,46 @@ namespace Microsoft.SharePoint.Client
             clientContext.Load(term.Labels);
             clientContext.ExecuteQueryRetry();
 
-            if (!term.Labels.Any(l => l.Language == lcid))
-            {
-                term.CreateLabel(labelName, lcid, isDefault);
-                clientContext.ExecuteQueryRetry();
-            }
-            else if (term.Labels.Any(l => l.Language == lcid && l.Value != labelName))
-            {
-                var label = term.Labels.FirstOrDefault(l => l.Language == lcid);
-                label.Value = labelName;
 
-                if (isDefault)
+            // It's quite usual to get a TermStore Exception here - we can safely retry it in that case
+            var maxRetries = 3;
+            for (var iterator = 0; iterator <= maxRetries; iterator++)
+            {
+                try
                 {
-                    label.SetAsDefaultForLanguage();
+                    if (!term.Labels.Any(l => l.Language == lcid))
+                    {
+                        term.CreateLabel(labelName, lcid, isDefault);
+                        clientContext.ExecuteQueryRetry();
+                    }
+                    else if (term.Labels.Any(l => l.Language == lcid && l.Value != labelName))
+                    {
+                        var label = term.Labels.FirstOrDefault(l => l.Language == lcid);
+                        label.Value = labelName;
+
+                        if (isDefault)
+                        {
+                            label.SetAsDefaultForLanguage();
+                        }
+
+                        clientContext.Load(term.TermStore);
+                        clientContext.ExecuteQueryRetry();
+
+                        term.TermStore.CommitAll();
+                        clientContext.ExecuteQueryRetry();
+                    }
                 }
+                catch (Exception ex)
+                {
+                    if (ex.Message.StartsWith("TermStoreEx:") && iterator <= (maxRetries-1)) // if this keeps happening, we'll throw at the last try
+                    {
+                        Log.Warning("TermStore operation failed, retrying. Error: {0}", ex.Message);
+                        continue;
+                    }
 
-                clientContext.Load(term.TermStore);
-                clientContext.ExecuteQueryRetry();
-
-                term.TermStore.CommitAll();
-                term.TermStore.Context.ExecuteQueryRetryAsync();
-                label.Context.ExecuteQueryRetry();
-                clientContext.ExecuteQueryRetry();
+                    Log.Error(ex, "Error ensuring label for term {0} with LCID {1}", term.Name, lcid);
+                    throw;
+                }
             }
         }
 


### PR DESCRIPTION
## Why

This PR fixes the following issues:
- https://github.com/pnp/PnP-Sites-Core/issues/662 (legacy issue from PnP-Sites-Core)
- https://github.com/pnp/powershell/issues/3096 (PnP PowerShell issue)

## What

The current implementation doesn't add labels to existing terms. There's an extension method called EnsureLabel that this PR changes to handle adding or updating new labels to terms.

## Known issues

- Working with term store is a little finicky here, too, so sometimes term store calls "just fail". Retry logic could be tweaked further to counter this.
- I'm not sure how term set labels can be set - the entity does not have labels, and adding to Names doesn't seem to do anything.