### PR TITLE
Fixing IsAvailableForTagging not being set correctly on a reused term

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
@@ -520,6 +520,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                     createdTerm = ((Term)parent).ReuseTerm(preExistingTerm, false);
                 }
 
+                // Since reuseterm ignores the IsAvailableForTagging flag, we're going to ensure it will be set as it was provided in the model
+                createdTerm.IsAvailableForTagging = modelTerm.IsAvailableForTagging;
+
                 if (modelTerm.IsSourceTerm)
                 {
                     preExistingTerm.ReassignSourceTerm(createdTerm);


### PR DESCRIPTION
Fixing IsAvailableForTagging not being set correctly on a reused term. It would always use the default of being true, even though the XML import would define it needing to be false. This fixes that it will apply whatever is configured in the XML.

<img width="854" alt="image" src="https://github.com/pnp/pnpframework/assets/5940670/ceb1373b-098d-4e90-bcaf-e5df3365b23f">
