### PR TITLE
Bump System.IdentityModel.Tokens.Jwt to 6.35.0

### DIFF
--- a/src/lib/PnP.Framework/PnP.Framework.csproj
+++ b/src/lib/PnP.Framework/PnP.Framework.csproj
@@ -259,7 +259,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="PnP.Core" Version="1.11.*-*" Condition="'$(PnPCoreSdkPath)' == ''" />
 		<PackageReference Include="Portable.Xaml" Version="0.26.0" />
-		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(PnPCoreSdkPath)' != ''">		


### PR DESCRIPTION
Old System.IdentityModel.Tokens.Jwt 6.27.0 is vulnerable and Visual studio does not allow to build it. 