### PR TITLE
Optimizations to "TokenParser"

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteSecurity.cs
@@ -267,7 +267,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     }
                 }
 
-                IEnumerable<AssociatedGroupToken> associatedGroupTokens = parser.Tokens.Where(t => t.GetType() == typeof(AssociatedGroupToken)).Cast<AssociatedGroupToken>();
+                IEnumerable<AssociatedGroupToken> associatedGroupTokens = parser.Tokens.OfType<AssociatedGroupToken>();
                 foreach (AssociatedGroupToken associatedGroupToken in associatedGroupTokens)
                 {
                     associatedGroupToken.ClearCache();

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/LocalizationToken.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/LocalizationToken.cs
@@ -1,8 +1,7 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using Microsoft.SharePoint.Client;
 using PnP.Framework.Attributes;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -13,45 +12,38 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
      Returns = "My List Title")]
     internal class LocalizationToken : TokenDefinition
     {
-        private readonly List<ResourceEntry> _resourceEntries;
-        private readonly int? _defaultLCID;
+        private readonly int _webLanguage;
+        private readonly int? _defaultLcid;
+        private readonly Dictionary<int, ResourceEntry> _entriesByLanguage;
 
-        public LocalizationToken(Web web, string key, List<ResourceEntry> resourceEntries, int? defaultLCID)
+        public IReadOnlyList<ResourceEntry> ResourceEntries { get; }
+
+        public LocalizationToken(Web web, string key, List<ResourceEntry> resourceEntries, int? defaultLcid)
             : base(web, $"{{loc:{Regex.Escape(key)}}}", $"{{localize:{Regex.Escape(key)}}}", $"{{localization:{Regex.Escape(key)}}}", $"{{resource:{Regex.Escape(key)}}}", $"{{res:{Regex.Escape(key)}}}")
         {
-            _resourceEntries = resourceEntries;
-            _defaultLCID = defaultLCID;
+            ResourceEntries = resourceEntries;
+            _defaultLcid = defaultLcid;
+            _webLanguage = (int)web.Language;
+            _entriesByLanguage = new Dictionary<int, ResourceEntry>(capacity: resourceEntries.Count + 1);
+
+            for (var index = 0; index < resourceEntries.Count; index++)
+            {
+                var entry = resourceEntries[index];
+                _entriesByLanguage[entry.LCID] = entry;
+            }
         }
 
         public override string GetReplaceValue()
         {
-            var entry = _resourceEntries.FirstOrDefault(r => r.LCID == this.Web.Language);
-            if (entry != null)
+            if (_entriesByLanguage.TryGetValue(_webLanguage, out ResourceEntry entry)
+                // Fallback to default LCID.
+                || (_defaultLcid.HasValue && _entriesByLanguage.TryGetValue(_defaultLcid.Value, out entry)))
             {
                 return entry.Value;
             }
-            else
-            {
-                // fallback to default LCID or to the first resource string
-                var defaultEntry = _defaultLCID.HasValue ?
-                    _resourceEntries.FirstOrDefault(r => r.LCID == _defaultLCID) :
-                    _resourceEntries.First();
 
-                if (defaultEntry != null)
-                {
-                    return defaultEntry.Value;
-                }
-                else
-                {
-                    return _resourceEntries.First().Value; //fallback to old logic as for me _defaultLCID has always a Value i.e. 0 or the correct LCID
-                }
-            }
-
-        }
-
-        public List<ResourceEntry> ResourceEntries
-        {
-            get { return _resourceEntries; }
+            // Fallback to old logic as for me _defaultLCID has always a Value i.e. 0 or the correct LCID.
+            return ResourceEntries[0].Value;
         }
     }
 }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/ResourceEntry.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/ResourceEntry.cs
@@ -2,7 +2,7 @@
 {
     internal class ResourceEntry
     {
-        public uint LCID { get; set; }
+        public int LCID { get; set; }
         public string Value { get; set; }
     }
 }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/SimpleTokenDefinition.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/TokenDefinitions/SimpleTokenDefinition.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System;
+using System.Text.RegularExpressions;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
 {
@@ -9,14 +11,26 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
     {
         protected string CacheValue;
         private readonly string[] _tokens;
+        private readonly string[] _unescapedTokens;
+        private readonly int _maximumTokenLength;
 
         /// <summary>
         /// Constructor
-        /// </summary>        
+        /// </summary>
         /// <param name="token">token</param>
         public SimpleTokenDefinition(params string[] token)
         {
-            this._tokens = token;
+            _tokens = token;
+            _unescapedTokens = GetUnescapedTokens(token);
+            _maximumTokenLength = GetMaximumTokenLength(token);
+        }
+
+        /// <summary>
+        /// Gets the amount of tokens hold by this token definition
+        /// </summary>
+        public int TokenCount
+        {
+            get => _tokens.Length;
         }
 
         /// <summary>
@@ -29,12 +43,21 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
         }
 
         /// <summary>
+        /// Gets the by <see cref="Regex.Unescape"/> processed tokens
+        /// </summary>
+        /// <returns>Returns array string of by <see cref="Regex.Unescape"/> processed tokens</returns>
+        public IReadOnlyList<string> GetUnescapedTokens()
+        {
+            return _unescapedTokens;
+        }
+
+        /// <summary>
         /// Gets token length in integer
         /// </summary>
         /// <returns>token length in integer</returns>
         public int GetTokenLength()
         {
-            return _tokens.Select(t => t.Length).Concat(new[] { 0 }).Max();
+            return _maximumTokenLength;
         }
 
         /// <summary>
@@ -48,7 +71,31 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.TokenDefinitions
         /// </summary>
         public void ClearCache()
         {
-            this.CacheValue = null;
+            CacheValue = null;
+        }
+
+        private static int GetMaximumTokenLength(IReadOnlyList<string> tokens)
+        {
+            var result = 0;
+
+            for (var index = 0; index < tokens.Count; index++)
+            {
+                result = Math.Max(result, tokens[index].Length);
+            }
+
+            return result;
+        }
+
+        private static string[] GetUnescapedTokens(IReadOnlyList<string> tokens)
+        {
+            var result = new string[tokens.Count];
+
+            for (var index = 0; index < tokens.Count; index++)
+            {
+                result[index] = Regex.Unescape(tokens[index]);
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
This Pull Requests makes changes to the `TokenParser` to optimize the performance when working with larger templates. There is the companion ticket #963 which also contains some questions, which might result in additional commits once clarified. The `Clone` topic is one of those.

As described in the ticket the performance of PnP was really bad when deploying a larger template which also contained a larger amount of localization resources. It took several minutes to "initialize the engine" (aka the `TokenParser`) and also up to minutes when deploying a field, content type or list, but the problem has been already described in greater detail in the ticket #963.

With the help of a profiler I was able to pinpoint the source of the problem to the `TokenParser`, which really taxed the CPU when processing the localization resources and also when parsing a string (`ParseString`) due to repeatedly iterating through all `TokenDefinition`, their tokens and processing them with `Regex.Unescape`. I made some changes to the initialization of the localization resource tokens and the parsing of strings, which greatly reduced the initialization time of the `TokenParser` and also the overall CPU utilization when working with `ParseString`.

The following main changes have been made.

* The token cache now only gets created when using `Rebase`, the private constructor (for cloning) and creating the instance.
* Added a cache for non-cacheable `TokenDefinition` containing the actual `TokenDefinition` instead of the value. This has been added to eliminate the need of creating a dictionary with all non-cacheable definitions most of the times when `ParseString` gets called.
* The normal and non-cacheable defintions cache gets updated by just processing the affected `TokenDefinition` when calling `AddToken` or `RebuildListTokens`. In most cases the cache dictionaries are initialized with a calculated capacity to avoid resizing operations.
* Changed `AddResourceTokens` to use a dictionary instead of a list to avoid costly lookup operations when adding `LocalizationToken`. Additionally the capacity of the `_tokens` list gets extended to a calculated amount beforehand to avoid resizing operations.
* `GetListTitleForMainLanguage` and `_listsTitles` are now instance members. This fixes issues with environments where multiple threads might deploy a template at the same time.
  * `GetListTitleForMainLanguage` now also uses a batch approach for retrieving the titles of the lists in order to reduce the time and amount of server calls required to retrieve them.
* Removed the sorting of `_tokens` when adding a token or creating a `TokenParser` instance. It looks like sorting the list is not/no longer required, but might be added back later based on the discussion in ticket #963.

The following additional changes have been made. The first two are not part of any of the commit messages due to an oversight on my side.

* **ResourceEntry**
  * Changed the type of the `LCID` property from `uint` to `int`.
* **LocalizationToken**
  * Changed `LocalizationToken` to use a `Dictionary` instead of a `List` to speed up the lookup performance when trying to retrieve a `ResourceEntry` for a specific language.
    * The `ResourceEntries` property is now also an `IReadOnlyList` instead of a `List`. A caller should not be able to at least add or remove a `ResourceEntry` on an `LocalizationToken` instance. He would still be able to manipulate the `ResourceEntry` itself though. The change should not have any impact on existing applications, because the whole class is `internal` and not available outside of the library.
* **TokenParser**
  * Formatted some code to enhance the readability.
  * Replaced some LINQ methods with native methods provided by the specific collection type.
  * Changed the code of some methods to exit them early, which reduces the nesting.
  * Removed unused parameters from private methods.
  * Removed some commented code.
  * Moved all variable declarations to the top of the class.
