### PR TITLE
Adding Managed Identity support to PnP Framework

### DIFF
--- a/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
@@ -353,6 +353,8 @@ namespace Microsoft.SharePoint.Client
         /// <returns>A ClientContext object created for the passed site URL</returns>
         internal static ClientContext Clone(this ClientRuntimeContext clientContext, ClientContext targetContext, Uri siteUrl, Dictionary<string, string> accessTokens = null)
         {
+            PnP.Framework.Diagnostics.Log.Debug(Constants.LOGGING_SOURCE, $"Cloning context for {siteUrl}");
+
             if (siteUrl == null)
             {
                 throw new ArgumentException(CoreResources.ClientContextExtensions_Clone_Url_of_the_site_is_required_, nameof(siteUrl));
@@ -370,9 +372,13 @@ namespace Microsoft.SharePoint.Client
             {
                 string newSiteUrl = siteUrl.ToString();
 
+                PnP.Framework.Diagnostics.Log.Debug(Constants.LOGGING_SOURCE, $"Checking for different audience {newSiteUrl}");
+
                 // A diffent host = different audience ==> new access token is needed
                 if (contextSettings.UsesDifferentAudience(newSiteUrl))
                 {
+
+                    PnP.Framework.Diagnostics.Log.Debug(Constants.LOGGING_SOURCE, $"Setting up context for different audience {contextSettings.Type}");
 
                     var authManager = contextSettings.AuthenticationManager;
                     ClientContext newClientContext = null;

--- a/src/lib/PnP.Framework/Extensions/TenantExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/TenantExtensions.cs
@@ -44,6 +44,8 @@ namespace Microsoft.SharePoint.Client
         /// <param name="configuration"></param>
         public static void ApplyTenantTemplate(this Tenant tenant, ProvisioningHierarchy tenantTemplate, string sequenceId, ApplyConfiguration configuration = null)
         {
+            Log.Debug(Constants.LOGGING_SOURCE, $"ApplyTenantTemplate");
+
             SiteToTemplateConversion engine = new SiteToTemplateConversion();
             engine.ApplyTenantTemplate(tenant, tenantTemplate, sequenceId, configuration);
         }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
@@ -9,6 +9,7 @@ using PnP.Framework.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace PnP.Framework.Provisioning.ObjectHandlers
 {
@@ -295,11 +296,21 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                         if (PnPProvisioningContext.Current != null)
                                         {                                            
                                             var graphBaseURI = AuthenticationManager.GetGraphBaseEndPoint(tenant.Context.GetAzureEnvironment());
-                                            try
+
+                                            // We're going to try to get an access token from a cookie first, if we have a delegate handler assigned that knows how to deal with the cookies
+                                            if (PnPProvisioningContext.Current.AcquireCookie != null)
                                             {
-                                                graphAccessToken = PnPProvisioningContext.Current.AcquireCookie(graphBaseURI.ToString());
+                                                try
+                                                {
+                                                    graphAccessToken = PnPProvisioningContext.Current.AcquireCookie(graphBaseURI.ToString());
+                                                }
+                                                catch
+                                                {
+                                                }
                                             }
-                                            catch
+
+                                            // Check if we managed to get an access token, if not, we're going to try getting one from the Microsoft Online authentication endpoints
+                                            if(string.IsNullOrEmpty(graphAccessToken))
                                             {
                                                 graphAccessToken = PnPProvisioningContext.Current.AcquireToken(graphBaseURI.Authority, null);
                                             }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/PnPProvisioningContext.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/PnPProvisioningContext.cs
@@ -119,7 +119,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         /// <returns>The Cookie for the requested resource</returns>
         public string AcquireCookie(string resource)
         {
-            return (this.AcquireCookieAsync(resource).GetAwaiter().GetResult());
+            // If there's a delegate hooked up to the cookie acquiring, trigger it, if not return a null to indicate it's not able to get a token through a cookie
+            return this.AcquireCookieAsync != null ? (this.AcquireCookieAsync(resource).GetAwaiter().GetResult()) : null;
         }
 
         ~PnPProvisioningContext()

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -167,6 +167,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     }
                 }
 
+                Log.Debug(Constants.LOGGING_SOURCE, $"Attaching object handlers");
+
                 List<ObjectHierarchyHandlerBase> objectHandlers = new List<ObjectHierarchyHandlerBase>
                 {
                     new ObjectHierarchyTenant(),

--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -1145,12 +1145,14 @@ namespace PnP.Framework.Sites
         /// <returns>True if in use, false otherwise</returns>
         public static async Task<Dictionary<string, string>> GetGroupInfoAsync(ClientContext context, string alias)
         {
+            Log.Debug(Constants.LOGGING_SOURCE, $"GetGroupInfoAsync");
+
             await new SynchronizationContextRemover();
 
             Dictionary<string, string> siteInfo = new Dictionary<string, string>();
 
-            context.Web.EnsureProperty(w => w.Url);
-            Log.Debug(Constants.LOGGING_SOURCE, $"Done with GetWebUrl");
+            Log.Debug(Constants.LOGGING_SOURCE, $"GetWebUrl");
+            context.Web.EnsureProperty(w => w.Url);            
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var httpClient = PnPHttpClient.Instance.GetHttpClient(context);
@@ -1165,6 +1167,8 @@ namespace PnP.Framework.Sites
                 request.Headers.Add("accept", "application/json;odata.metadata=none");
                 httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 request.Headers.Add("odata-version", "4.0");
+
+                Log.Debug(Constants.LOGGING_SOURCE, $"AuthenticateRequestAsync");
 
                 await PnPHttpClient.AuthenticateRequestAsync(request, context).ConfigureAwait(false);
 

--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -1150,6 +1150,7 @@ namespace PnP.Framework.Sites
             Dictionary<string, string> siteInfo = new Dictionary<string, string>();
 
             context.Web.EnsureProperty(w => w.Url);
+            Log.Debug(Constants.LOGGING_SOURCE, $"Done with GetWebUrl");
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var httpClient = PnPHttpClient.Instance.GetHttpClient(context);

--- a/src/lib/PnP.Framework/Utilities/Context/ClientContextType.cs
+++ b/src/lib/PnP.Framework/Utilities/Context/ClientContextType.cs
@@ -1,5 +1,8 @@
 ﻿namespace PnP.Framework.Utilities.Context
 {
+    /// <summary>
+    /// The authentication type used for setting up a ClientContext
+    /// </summary>
     public enum ClientContextType
     {
         SharePointACSAppOnly = 0,
@@ -11,6 +14,16 @@
         DeviceLogin = 6,
         OnPremises = 7,
         AccessToken = 8,
-        PnPCoreSdk = 9
+        PnPCoreSdk = 9,
+        
+        /// <summary>
+        /// System Assigned Managed Identity in Azure
+        /// </summary>
+        SystemAssignedManagedIdentity = 10,
+
+        /// <summary>
+        /// User Assigned Managed Identity in Azure
+        /// </summary>
+        UserAssignedManagedIdentity = 11
     }
 }

--- a/src/lib/PnP.Framework/Utilities/Context/ManagedIdentityType.cs
+++ b/src/lib/PnP.Framework/Utilities/Context/ManagedIdentityType.cs
@@ -1,0 +1,28 @@
+﻿namespace PnP.Framework.Utilities.Context
+{
+    /// <summary>
+    /// Types of Managed Identity supported within the Framework
+    /// </summary>
+    public enum ManagedIdentityType
+    {
+        /// <summary>
+        /// System Assigned Managed Identity
+        /// </summary>
+        SystemAssigned = 0,
+
+        /// <summary>
+        /// User Assigned Managed Identity, referenced by its client Id
+        /// </summary>
+        UserAssignedByClientId = 1,
+
+        /// <summary>
+        /// User Assigned Managed Identity, referenced by its object Id
+        /// </summary>
+        UserAssignedByObjectId = 2,
+
+        /// <summary>
+        /// User Assigned Managed Identity, refernced by its resource Id
+        /// </summary>
+        UserAssignedByResourceId = 3
+    }
+}


### PR DESCRIPTION
Adding Managed Identity support for PnP Framework means i.e. you can now use PnP tenant provisioning within a managed identity structure