### PR TITLE
fix(auth): fix issue in ConfigureOnPremisesContext causing 403 forbidden responses on on-premise environments

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -1363,7 +1363,7 @@ namespace PnP.Framework
                 //       PowerShell do support SharePoint on-premises.
                 webRequestEventArgs.WebRequestExecutor.WebRequest.Credentials = (sender as ClientContext).Credentials;
                 // CSOM for .NET Standard does not handle request digest management, a POST to client.svc requires a digest, so ensuring that
-                webRequestEventArgs.WebRequestExecutor.WebRequest.Headers.Add("X-RequestDigest", (sender as ClientContext).GetOnPremisesRequestDigestAsync().GetAwaiter().GetResult());
+                webRequestEventArgs.WebRequestExecutor.RequestHeaders["X-RequestDigest"] = (sender as ClientContext).GetOnPremisesRequestDigestAsync().GetAwaiter().GetResult();
                 // Add Request Header to force Windows Authentication which avoids an issue if multiple authentication providers are enabled on a webapplication
                 webRequestEventArgs.WebRequestExecutor.RequestHeaders["X-FORMS_BASED_AUTH_ACCEPTED"] = "f";
             };


### PR DESCRIPTION
On on-premise environments, it happens that the GetUpdatedFormDigestInformation is invoked multiple times causing multiple digest values in the X-RequestDigest header. This in turn causes SharePoint to throw 403: forbidden responses.

This small change fixes this issue.

Closes #1010 