### PR TITLE
we should specify Uri, otherwise it will throw NRE

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -899,7 +899,7 @@ namespace PnP.Framework
                         {
                             throw new ArgumentException($"{nameof(GetAccessTokenAsync)}() called without an ACS token generator. Specify in {nameof(AuthenticationManager)} constructor the authentication parameters");
                         }
-                        return acsTokenGenerator.GetToken(null);
+                        return acsTokenGenerator.GetToken(uri);
                     }
                 case ClientContextType.AccessToken:
                     {


### PR DESCRIPTION
Repro steps (F#):

let am=new AuthenticationManager()
let ctx=am.GetACSAppOnlyContext("https://contoso.sharepoint.com/sites/mysite", clientId, clientSecret)
//..................................
let cs=ctx.GetContextSettings()
let t=cs.AuthenticationManager.GetAccessToken("https://contoso.sharepoint.com/sites/mysite")
        