### PR TITLE
Update AuthenticationManager.cs for GCC SharePoint suffix value

### DIFF
--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -1683,7 +1683,7 @@ namespace PnP.Framework
             return (environment) switch
             {
                 AzureEnvironment.Production => "com",
-                AzureEnvironment.USGovernment => "us",
+                AzureEnvironment.USGovernment => "com",
                 AzureEnvironment.USGovernmentHigh => "us",
                 AzureEnvironment.USGovernmentDoD => "us",
                 AzureEnvironment.Germany => "de",


### PR DESCRIPTION
Updating UsGovernment enum for SharePoint domain suffix to be .com vs previous .us.