### PR TITLE
Fix check for HeaderTypes as new PageTitle WebPart in OneColumnFullWIth is not always in first section

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -384,9 +384,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         }
                     case ClientSidePageHeaderType.Default:
                         {
-                            //Message ID: MC791596 / Roadmap ID: 386904
-                            if (clientSidePage.Sections.Any() && clientSidePage.Sections.First().Type == CanvasSectionType.OneColumnFullWidth && 
-                                clientSidePage.Sections.First().Controls.Any(c => c.Type == WebPartType.PageTitle))
+                            //Message ID: MC791596 / Roadmap ID: 386904 =>based on #1058 the PageTitle WebPart is not always in first section
+                            if (clientSidePage.Sections.Any(s => s.Type == CanvasSectionType.OneColumnFullWidth && s.Controls.Any(c => c.Type == WebPartType.PageTitle)))
                             {
                                 page.SetPageTitleWebPartPageHeader();
                             }


### PR DESCRIPTION
The original fix was expecting the PageTitle WebPart to be the first in the first section which needs to be a OneColumnFullWith.
#1058
#1043

It seems that this assumption was wrong and it can be in any section. The check has been changed to reflect this.
This fix is related to the pnp.core fix https://github.com/pnp/pnpcore/pull/1543.

