### PR TITLE
Added support for disabling loading all site collection term groups

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Model/Configuration/ApplyConfiguration.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/Configuration/ApplyConfiguration.cs
@@ -49,6 +49,7 @@ namespace PnP.Framework.Provisioning.Model.Configuration
 
         [JsonPropertyName("parameters")]
         public Dictionary<string, string> Parameters { get; set; } = new Dictionary<string, string>();
+
         /// <summary>
         /// Defines Tenant Extraction Settings
         /// </summary>
@@ -73,23 +74,31 @@ namespace PnP.Framework.Provisioning.Model.Configuration
         [JsonPropertyName("extensibility")]
         public Extensibility.ApplyExtensibilityConfiguration Extensibility { get; set; } = new Extensibility.ApplyExtensibilityConfiguration();
 
+        /// <summary>
+        /// Specifies whether to also load site collection term groups when initializing the <see cref="TokenParser"/>. If
+        /// <c>false</c>, only normal term groups will be loaded. This does not affect loading the site collection term group
+        /// when one of the <c>sitecollectionterm</c> tokens was found.
+        /// </summary>
+        [JsonPropertyName("loadSiteCollectionTermGroups")]
+        public bool LoadSiteCollectionTermGroups { get; set; } = true;
+
         public ProvisioningTemplateApplyingInformation ToApplyingInformation()
         {
             var ai = new ProvisioningTemplateApplyingInformation
             {
-                ApplyConfiguration = this
+                ApplyConfiguration = this,
+                ProvisionContentTypesToSubWebs = this.ContentTypes.ProvisionContentTypesToSubWebs,
+                OverwriteSystemPropertyBagValues = this.PropertyBag.OverwriteSystemValues,
+                IgnoreDuplicateDataRowErrors = this.Lists.IgnoreDuplicateDataRowErrors,
+                ClearNavigation = this.Navigation.ClearNavigation,
+                ProvisionFieldsToSubWebs = this.Fields.ProvisionFieldsToSubWebs,
+                LoadSiteCollectionTermGroups = LoadSiteCollectionTermGroups
             };
 
             if (this.AccessTokens != null && this.AccessTokens.Any())
             {
                 ai.AccessTokens = this.AccessTokens;
             }
-
-            ai.ProvisionContentTypesToSubWebs = this.ContentTypes.ProvisionContentTypesToSubWebs;
-            ai.OverwriteSystemPropertyBagValues = this.PropertyBag.OverwriteSystemValues;
-            ai.IgnoreDuplicateDataRowErrors = this.Lists.IgnoreDuplicateDataRowErrors;
-            ai.ClearNavigation = this.Navigation.ClearNavigation;
-            ai.ProvisionFieldsToSubWebs = this.Fields.ProvisionFieldsToSubWebs;
 
             if (Handlers.Any())
             {
@@ -178,12 +187,13 @@ namespace PnP.Framework.Provisioning.Model.Configuration
             config.ContentTypes.ProvisionContentTypesToSubWebs = information.ProvisionContentTypesToSubWebs;
             config.Fields.ProvisionFieldsToSubWebs = information.ProvisionFieldsToSubWebs;
             config.SiteProvisionedDelegate = information.SiteProvisionedDelegate;
+            config.LoadSiteCollectionTermGroups = information.LoadSiteCollectionTermGroups;
+
             return config;
         }
 
         public static ApplyConfiguration FromString(string input)
         {
-          
             return JsonSerializer.Deserialize<ApplyConfiguration>(input);
         }
     }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectComposedLook.cs
@@ -128,7 +128,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ComposedLooks_ExtractObjects_Creating_SharePointConnector);
                             // Let's create a SharePoint connector since our files anyhow are in SharePoint at this moment
-                            TokenParser parser = new TokenParser(web, template);
+                            var parser = new TokenParser(web, template, new ProvisioningTemplateApplyingInformation { LoadSiteCollectionTermGroups = creationInfo.LoadSiteCollectionTermGroups });
                             DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, parser.ParseString(composedLook.BackgroundFile), scope);
                             DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, parser.ParseString(composedLook.ColorFile), scope);
                             DownLoadFile(spConnector, spConnectorRoot, creationInfo.FileConnector, web.Url, parser.ParseString(composedLook.FontFile), scope);

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
@@ -724,7 +724,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                         //}
                                         //else
                                         //{
-                                        //    siteTokenParser.Rebase(web, provisioningTemplate);
+                                        //    siteTokenParser.Rebase(web, provisioningTemplate, provisioningTemplateApplyingInformation);
                                         //}
                                         WriteMessage($"Applying Template", ProvisioningMessageType.Progress);
                                         new SiteToTemplateConversion().ApplyRemoteTemplate(web, provisioningTemplate, provisioningTemplateApplyingInformation, true, siteTokenParser);
@@ -871,7 +871,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     provisioningTemplate.Connector = hierarchy.Connector;
                     if (tokenParser == null)
                     {
-                        tokenParser = new TokenParser(subweb, provisioningTemplate);
+                        tokenParser = new TokenParser(subweb, provisioningTemplate, provisioningTemplateApplyingInformation);
                     }
                     else
                     {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -15,12 +15,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         public override string Name => "Term Groups";
 
         public override string InternalName => "TermGroups";
+
         public override TokenParser ProvisionObjects(Web web, Model.ProvisioningTemplate template, TokenParser parser,
             ProvisioningTemplateApplyingInformation applyingInformation)
         {
-            using (var scope = new PnPMonitoredScope(this.Name))
+            using (var scope = new PnPMonitoredScope(Name))
             {
-                this.reusedTerms = new List<TermGroupHelper.ReusedTerm>();
+                reusedTerms = new List<TermGroupHelper.ReusedTerm>();
 
                 TaxonomySession taxSession = TaxonomySession.GetTaxonomySession(web.Context);
                 TermStore termStore;
@@ -32,7 +33,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     termStore = taxSession.GetDefaultKeywordsTermStore();
 
                     web.Context.Load(termStore, ts => ts.Languages, ts => ts.DefaultLanguage);
-                    siteCollectionTermGroup = termStore.GetSiteCollectionGroup((web.Context as ClientContext).Site, false);
+                    siteCollectionTermGroup = termStore.GetSiteCollectionGroup(((ClientContext)web.Context).Site, createIfMissing: false);
 
                     if (applyingInformation.LoadSiteCollectionTermGroups)
                     {
@@ -47,22 +48,40 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                     termSet => termSet.Name,
                                     termSet => termSet.Id)
                             ));
+
+                        web.Context.Load(siteCollectionTermGroup);
+                        web.Context.ExecuteQueryRetry();
                     }
                     else
                     {
-                        termGroups = web.Context.LoadQuery(termStore
-                            .Groups
-                            .Where(group => !group.IsSiteCollectionGroup)
-                            .Include(
-                                group => group.Name,
-                                group => group.Id,
-                                group => group.TermSets.Include(
-                                    termSet => termSet.Name,
-                                    termSet => termSet.Id)));
-                    }
+                        IEnumerable<TermGroup> groups = web
+                            .Context
+                            .LoadQuery(termStore
+                                .Groups
+                                .Where(group => !group.IsSiteCollectionGroup)
+                                .Include(
+                                    group => group.Name,
+                                    group => group.Id,
+                                    group => group.TermSets.Include(
+                                        termSet => termSet.Name,
+                                        termSet => termSet.Id)));
+                        web.Context.ExecuteQueryRetry();
 
-                    web.Context.Load(siteCollectionTermGroup);
-                    web.Context.ExecuteQueryRetry();
+                        // Convert the loaded term groups to a list and add the site collection one.
+                        List<TermGroup> loadedTermGroups = groups.ToList();
+                        loadedTermGroups.Add(siteCollectionTermGroup);
+
+                        web.Context.Load(
+                            siteCollectionTermGroup,
+                            group => group.Name,
+                            group => group.Id,
+                            group => group.TermSets.Include(
+                                termSet => termSet.Name,
+                                termSet => termSet.Id));
+                        web.Context.ExecuteQueryRetry();
+
+                        termGroups = loadedTermGroups;
+                    }
                 }
                 catch (ServerException)
                 {
@@ -75,10 +94,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 foreach (var modelTermGroup in template.TermGroups)
                 {
-                    this.reusedTerms.AddRange(TermGroupHelper.ProcessGroup(web.Context as ClientContext, taxSession, termStore, termGroups, modelTermGroup, siteCollectionTermGroup, parser, scope));
+                    reusedTerms.AddRange(TermGroupHelper.ProcessGroup(web.Context as ClientContext, taxSession, termStore, termGroups, modelTermGroup, siteCollectionTermGroup, parser, scope));
                 }
 
-                foreach (var reusedTerm in this.reusedTerms)
+                foreach (var reusedTerm in reusedTerms)
                 {
                     TermGroupHelper.TryReuseTerm(web.Context as ClientContext, reusedTerm.ModelTerm, reusedTerm.Parent, reusedTerm.TermStore, parser, scope);
                 }
@@ -94,7 +113,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         public override Model.ProvisioningTemplate ExtractObjects(Web web, Model.ProvisioningTemplate template, ProvisioningTemplateCreationInformation creationInfo)
         {
-            using (var scope = new PnPMonitoredScope(this.Name))
+            using (var scope = new PnPMonitoredScope(Name))
             {
                 if (creationInfo.IncludeSiteCollectionTermGroup || creationInfo.IncludeAllTermGroups)
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ProvisioningTemplateApplyingInformation.cs
@@ -34,16 +34,21 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
     {
         private Handlers handlersToProcess = Handlers.All;
         private List<ExtensibilityHandler> extensibilityHandlers = new List<ExtensibilityHandler>();
+        private Dictionary<String, String> _accessTokens;
 
         public ProvisioningProgressDelegate ProgressDelegate { get; set; }
+
         public ProvisioningMessagesDelegate MessagesDelegate { get; set; }
+
         public ProvisioningSiteProvisionedDelegate SiteProvisionedDelegate { get; set; }
 
         internal ApplyConfiguration ApplyConfiguration { get; set; }
+
         /// <summary>
         /// If true then persists template information
         /// </summary>
 		public bool PersistTemplateInfo { get; set; } = true;
+
         /// <summary>
         /// If true, system propertybag entries that start with _, vti_, dlc_ etc. will be overwritten if overwrite = true on the PropertyBagEntry. If not true those keys will be skipped, regardless of the overwrite property of the entry.
         /// </summary>
@@ -53,6 +58,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         /// If true, existing navigation nodes of the site (where applicable) will be cleared out before applying the navigation nodes from the template (if any). This setting will override any settings made in the template.
         /// </summary>
         public bool ClearNavigation { get; set; }
+
         /// <summary>
         /// If true then duplicate id errors when the same importing datarows simply generate a warning don't stop the engine. Reason for this is being able to apply the same template multiple times (Delta handling)
         /// without that failing cause the same record is being added twice
@@ -68,6 +74,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         /// If true then any fields in the template will be provisioned to subwebs
         /// </summary>
         public bool ProvisionFieldsToSubWebs { get; set; }
+
+        /// <summary>
+        /// Specifies whether to also load site collection term groups when initializing the <see cref="TokenParser"/>. If
+        /// <c>false</c>, only normal term groups will be loaded. This does not affect loading the site collection term group
+        /// when one of the <c>sitecollectionterm</c> tokens was found.
+        /// </summary>
+        public bool LoadSiteCollectionTermGroups { get; set; } = true;
 
         /// <summary>
         /// Lists of Handlers to process
@@ -99,8 +112,6 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 extensibilityHandlers = value;
             }
         }
-
-        private Dictionary<String, String> _accessTokens;
 
         /// <summary>
         /// Allows to provide a dictionary of custom OAuth access tokens

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -334,6 +334,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         public List<String> ListsToExtract { get; set; } = new List<String>();
 
         /// <summary>
+        /// Specifies whether to also load site collection term groups when initializing the <see cref="TokenParser"/>. If
+        /// <c>false</c>, only normal term groups will be loaded. This does not affect loading the site collection term group
+        /// when one of the <c>sitecollectionterm</c> tokens was found.
+        /// </summary>
+        public bool LoadSiteCollectionTermGroups { get; set; } = true;
+
+        /// <summary>
         /// List which contains information about resource tokens used and/or created during the extraction of a template.
         /// </summary>
         internal List<Tuple<string, int, string>> ResourceTokens { get; } = new List<Tuple<string, int, string>>();

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/SiteToTemplateConversion.cs
@@ -184,7 +184,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 int step = 2;
 
-                TokenParser sequenceTokenParser = new TokenParser(tenant, hierarchy);
+                TokenParser sequenceTokenParser = new TokenParser(tenant, hierarchy, new ProvisioningTemplateApplyingInformation { LoadSiteCollectionTermGroups = configuration.LoadSiteCollectionTermGroups });
 
                 CallWebHooks(hierarchy.Templates.FirstOrDefault(), sequenceTokenParser,
                     ProvisioningTemplateWebhookKind.ProvisioningStarted);
@@ -414,7 +414,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 progressDelegate?.Invoke("Initializing engine", 1, count); // handlers + initializing message)
                 if (tokenParser == null)
                 {
-                    tokenParser = new TokenParser(web, template);
+                    tokenParser = new TokenParser(web, template, provisioningInfo);
                 }
                 if (provisioningInfo.HandlersToProcess.HasFlag(Handlers.ExtensibilityProviders))
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/TermGroupHelper.cs
@@ -10,7 +10,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
 {
     internal static class TermGroupHelper
     {
-        internal static List<ReusedTerm> ProcessGroup(ClientContext context, TaxonomySession session, TermStore termStore, Model.TermGroup modelTermGroup, TermGroup siteCollectionTermGroup, TokenParser parser, PnPMonitoredScope scope)
+        internal static List<ReusedTerm> ProcessGroup(ClientContext context, TaxonomySession session, TermStore termStore, IEnumerable<TermGroup> termGroups, Model.TermGroup modelTermGroup, TermGroup siteCollectionTermGroup, TokenParser parser, PnPMonitoredScope scope)
         {
             List<ReusedTerm> reusedTerms = new List<ReusedTerm>();
 
@@ -26,7 +26,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             var normalizedGroupName = TaxonomyItem.NormalizeName(context, modelGroupName);
             context.ExecuteQueryRetry();
 
-            TermGroup group = termStore.Groups.FirstOrDefault(
+            TermGroup group = termGroups.FirstOrDefault(
                 g => g.Id == modelTermGroup.Id || g.Name == normalizedGroupName.Value);
             if (group == null)
             {
@@ -45,7 +45,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 }
                 else
                 {
-                    group = termStore.Groups.FirstOrDefault(g => g.Name == normalizedGroupName.Value);
+                    group = termGroups.FirstOrDefault(g => g.Name == normalizedGroupName.Value);
 
                     if (group == null)
                     {


### PR DESCRIPTION
This pull requests adds the support to disable the loading of all site collection-related term groups when initializing the `TokenParser`.

Currently `TokenParser.AddTermStoreTokens` would load all available term groups from the term store when at least one `termsetid` token was found. Yesterday (2024-10-07) at 9:21 UTC we encountered the first instance of a timeout issue on one larger tenant, which was clearly caused by the `AddTermStoreTokens` method of `TokenParser` due to the stack trace. The request was canceled after three minutes.

```text
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   ...
   at Microsoft.SharePoint.Client.ClientContextExtensions.ExecuteQueryRetry(ClientRuntimeContext clientContext, Int32 retryCount, String userAgent)
   at PnP.Framework.Provisioning.ObjectHandlers.TokenParser.AddTermStoreTokens(Web web, List`1 tokenIds)
   at PnP.Framework.Provisioning.ObjectHandlers.TokenParser..ctor(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)
   at PnP.Framework.Provisioning.ObjectHandlers.SiteToTemplateConversion.ApplyRemoteTemplate(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation provisioningInfo, Boolean calledFromHierarchy, TokenParser tokenParser)
   ...
```

After some manual tests we figured out that loading all available term groups with their term sets caused the issue. Removing the term sets from the loading process solved the problem, but would defeat the purpose of the whole operation. During those tests we also realized that loading the term groups without any conditions would return (on that tenant) over 29,000 entries. Most of them were site collection term groups. The same operation on another large tenant finished after a few seconds, but returned only around 28,800 entries. So we don't know if this is just an issue on that one specific tenant, or if 29,000 is somehow a magic barrier and the other tenant is just on the edge to experience the same issue.

This could also be caused by one or more site collection term groups, which contain a larger amount of term sets, but we have not checked this yet. It also does not make in most cases sense for PnP to load all term groups including the site collection ones, because most templates might contain a reference to the site collection term group of the site it gets applied to, but not references to those from other site collections. Excluding them also greatly reduces the amount of tokens the `TokenParser` has to handle.

To remedy this issue we added the `LoadSiteCollectionTermGroups` property to the `ProvisioningTemplateApplyingInformation` and `ProvisioningTemplateCreationInformation` class. It is `true` by default to ensure the same behavior as before. Changing it to `false` will change the query with which the term groups get loaded from a normal `Load` to a `LoadQuery`, that excludes all groups which are related to a site collection (`IsSiteCollectionGroup` property). The `sitecollectionterm` token are not affected by this change and `AddTermStoreTokens` will still load information about the term group of the current site collection. Beside the `TokenParser` class `ObjectTermGroups` and `ObjectHierarchySequenceTermGroups` have been changed too, because they also load all term groups and would cause the same issue.

We tested the changes and deployed them already to our production environment using a reference to the project instead of using the NuGet package, because it was no longer possible to deploy any templates due to the timeout issue. We haven't seen any issues related to the changes yet. The hierarchy-related logic has also been changed, but because we don't use it it was not easily possible to test.