### PR TITLE
Giving support for Everyone except external users during the ListItem data row extraction

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -649,6 +649,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     if (userMultiFieldValue != null)
                     {
                         value = string.Join(",", userMultiFieldValue.Select(u => u.Email).ToArray())?.TrimEnd(new char[] { ',' }).Trim(new char[] { ',' });
+                        if (userMultiFieldValue.Any(u => u.LookupValue == web.GetEveryoneExceptExternalUsersClaimName()))
+                        {
+                            value = value + ",{everyonebutexternalusers}";
+                        }
                     }
                     break;
                 case "Lookup":

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -641,7 +641,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     var userFieldValue = fieldValue.Value as Microsoft.SharePoint.Client.FieldUserValue;
                     if (userFieldValue != null)
                     {
-                        value = userFieldValue.Email;
+                        if (!string.IsNullOrEmpty(userFieldValue.Email))
+                            value = userFieldValue.Email;
+                        else if (userFieldValue.LookupValue == web.GetEveryoneExceptExternalUsersClaimName())
+                            value = "{everyonebutexternalusers}";
                     }
                     break;
                 case "UserMulti":
@@ -651,7 +654,9 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         value = string.Join(",", userMultiFieldValue.Select(u => u.Email).ToArray())?.TrimEnd(new char[] { ',' }).Trim(new char[] { ',' });
                         if (userMultiFieldValue.Any(u => u.LookupValue == web.GetEveryoneExceptExternalUsersClaimName()))
                         {
-                            value = value + ",{everyonebutexternalusers}";
+                            if (!string.IsNullOrEmpty(value))
+                                value = value + ",";
+                            value = value + "{everyonebutexternalusers}";
                         }
                     }
                     break;


### PR DESCRIPTION
Currently when extracting list instance data rows for user fields, the user "Everyone except external users" is ignored.
This commit tries to give support for it.
After this, it will look like this:

<pnp:DataValue FieldName="CustomField">alaynawhite@whatever.onmicrosoft.com,Knowledgegroup@whatever.onmicrosoft.com,AnotherGroup@whatever.onmicrosoft.com,{everyonebutexternalusers}</pnp:DataValue>


              