### PR TITLE
Improves handling taxonomy custom sort order by checking for empty values

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTermGroups.cs
@@ -311,9 +311,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 {
                     var sortOrder = customSortOrder.Split(new[] { ':' }).ToList();
 
-                    var currentTermIndex = sortOrder.Where(i => new Guid(i) == term.Id).FirstOrDefault();
+                    var currentTermIndex = sortOrder.Where(i => !String.IsNullOrEmpty(i) && new Guid(i) == term.Id).FirstOrDefault();
                     modelTerm.CustomSortOrder = sortOrder.IndexOf(currentTermIndex) + 1;
-
                 }
             }
             termsToReturn = termsToReturn.OrderBy(t => t.CustomSortOrder).ToList();

--- a/src/lib/PnP.Framework/Provisioning/Providers/Xml/PnPObjectsMapper.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Xml/PnPObjectsMapper.cs
@@ -218,7 +218,7 @@ namespace PnP.Framework.Provisioning.Providers.Xml
                         catch (Exception)
                         {
                             // Right now, for testing purposes, I just output and skip any issue
-                            // TODO: Handle issues insteaf of skipping them, we need to find a common pattern
+                            // TODO: Handle issues instead of skipping them, we need to find a common pattern
                         }
                     }
                 }


### PR DESCRIPTION
Fix #1075 by improving handling custom sort order by checking for empty values.

Also fixes a typo in someone else's comment - sorry, it caught my eye :)