### PR TITLE
Handle urls ending with / when creating new sites

### DIFF
--- a/src/lib/PnP.Framework/Sites/SiteCollection.cs
+++ b/src/lib/PnP.Framework/Sites/SiteCollection.cs
@@ -904,7 +904,7 @@ namespace PnP.Framework.Sites
             if (siteCollectionCreationInformation.Url.IndexOf("/sites/", StringComparison.InvariantCultureIgnoreCase) > -1 || siteCollectionCreationInformation.Url.IndexOf("/teams/", StringComparison.InvariantCultureIgnoreCase) > -1)
             {
                 // Split the URL by '/'
-                string[] urlParts = siteCollectionCreationInformation.Url.Split('/');
+                string[] urlParts = siteCollectionCreationInformation.Url.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
                 // Get the last part of the URL after "sites"
                 string lastPart = urlParts[urlParts.Length - 1];


### PR DESCRIPTION
Handle urls ending with / when creating new sites by removing any empty entry after splitting the url by /.
This is needed when the url ends with / as the last part after `Split('/')` will just be an empty string, causing `Replace("", "")` to be called, throwing an exception.

This has been reported at https://github.com/pnp/powershell/issues/4491 and can be reproduced calling New-PnPSite:
```powershell
 New-PnPSite -Type TeamSiteWithoutMicrosoft365Group -Owner <owner upn> -Url "https://<tenant>.sharepoint.com/sites/TestWithSlash/" -Title "Test With Slash"
```
![image](https://github.com/user-attachments/assets/6d17d4bf-0788-4b6f-96e5-47a20adcc9d9)

The PR fixes the issue and the site is created:
![image](https://github.com/user-attachments/assets/5f50bdb7-ebfc-49a2-8621-3aeda33c8789)

