### PR TITLE
General channel is not created by default anymore, check first channel when creating and initialize Teams

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectTeams.cs
@@ -2010,12 +2010,12 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
             }
 
             var existingChannels = JToken.Parse(channels)["value"];
-
-            var existingChannel = existingChannels?.FirstOrDefault(x => x["displayName"].ToString() == "General");
+            
+            var existingChannel = existingChannels?.FirstOrDefault();
 
             if (existingChannel == null)
             {
-                throw new Exception($"Could not get General channel of team with id {teamId}.");
+                throw new Exception($"Could not get any channel for team with id {teamId}.");
             }
 
             wait = true;
@@ -2039,7 +2039,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
                 if (iterations > 60)
                 {
-                    throw new Exception($"Could not get drive item of General channel in team with id {teamId} within timeout.");
+                    throw new Exception($"Could not get drive item of first channel in team with id {teamId} within timeout.");
                 }
             }
         }


### PR DESCRIPTION
General channel is not created by default anymore.
Now Teams allows to define the first Channel name when creating the Teams.
Initialize the first channel found.