### PR TITLE
Include Webhook ClientState in Model

### DIFF
--- a/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer201909Tests.cs
+++ b/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer201909Tests.cs
@@ -3137,6 +3137,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("fake-template.stp", list.TemplateInternalName);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("ABC", list.Webhooks[0].ClientState);
 
             // security
             var security = list.Security;
@@ -3413,7 +3414,8 @@ namespace PnP.Framework.Test.Framework.Providers
             list.Webhooks.Add(new PnP.Framework.Provisioning.Model.Webhook
             {
                 ExpiresInDays = 120,
-                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener"
+                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
+                ClientState = "CBA"
             });
 
             list.IRMSettings = new PnP.Framework.Provisioning.Model.IRMSettings
@@ -3668,6 +3670,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("/Lists/ProjectDocuments", l.Url);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("CBA", list.Webhooks[0].ClientState);
 
             Assert.IsNotNull(l.Security);
             var security = l.Security.BreakRoleInheritance;
@@ -4799,6 +4802,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual(120, webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("DEF", webhooks[0].ClientState);
         }
 
         [TestMethod]
@@ -4813,7 +4817,8 @@ namespace PnP.Framework.Test.Framework.Providers
             {
                 SiteWebhookType = SiteWebhookType.WebCreated,
                 ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
-                ExpiresInDays = 120
+                ExpiresInDays = 120,
+                ClientState = "FED"
             });
 
             var serializer = new XMLPnPSchemaV201909Serializer();
@@ -4833,6 +4838,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("120", webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookSiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("FED", webhooks[0].ClientState);
         }
 
         [TestMethod]

--- a/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202002Tests.cs
+++ b/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202002Tests.cs
@@ -3238,6 +3238,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("fake-template.stp", list.TemplateInternalName);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("ABC", list.Webhooks[0].ClientState);
 
             // security
             var security = list.Security;
@@ -3514,7 +3515,8 @@ namespace PnP.Framework.Test.Framework.Providers
             list.Webhooks.Add(new PnP.Framework.Provisioning.Model.Webhook
             {
                 ExpiresInDays = 120,
-                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener"
+                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
+                ClientState = "CBA"
             });
 
             list.IRMSettings = new PnP.Framework.Provisioning.Model.IRMSettings
@@ -3769,6 +3771,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("/Lists/ProjectDocuments", l.Url);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("CBA", list.Webhooks[0].ClientState);
 
             Assert.IsNotNull(l.Security);
             var security = l.Security.BreakRoleInheritance;
@@ -4900,6 +4903,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual(120, webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("DEF", webhooks[0].ClientState);
         }
 
         [TestMethod]
@@ -4914,7 +4918,8 @@ namespace PnP.Framework.Test.Framework.Providers
             {
                 SiteWebhookType = SiteWebhookType.WebCreated,
                 ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
-                ExpiresInDays = 120
+                ExpiresInDays = 120,
+                ClientState = "FED"
             });
 
             var serializer = new XMLPnPSchemaV202002Serializer();
@@ -4934,6 +4939,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("120", webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookSiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("FED", webhooks[0].ClientState);
         }
 
         [TestMethod]

--- a/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202103Tests.cs
+++ b/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202103Tests.cs
@@ -3403,6 +3403,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("fake-template.stp", list.TemplateInternalName);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("ABC", list.Webhooks[0].ClientState);
 
             // security
             var security = list.Security;
@@ -3687,7 +3688,8 @@ namespace PnP.Framework.Test.Framework.Providers
             list.Webhooks.Add(new PnP.Framework.Provisioning.Model.Webhook
             {
                 ExpiresInDays = 120,
-                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener"
+                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
+                ClientState = "CBA"
             });
 
             list.IRMSettings = new PnP.Framework.Provisioning.Model.IRMSettings
@@ -3942,6 +3944,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("/Lists/ProjectDocuments", l.Url);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("CBA", list.Webhooks[0].ClientState);
 
             Assert.IsNotNull(l.Security);
             var security = l.Security.BreakRoleInheritance;
@@ -5084,6 +5087,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual(120, webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("DEF", webhooks[0].ClientState);
         }
 
         [TestMethod]
@@ -5098,7 +5102,8 @@ namespace PnP.Framework.Test.Framework.Providers
             {
                 SiteWebhookType = SiteWebhookType.WebCreated,
                 ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
-                ExpiresInDays = 120
+                ExpiresInDays = 120,
+                ClientState = "FED"
             });
 
             var serializer = new XMLPnPSchemaV202103Serializer();
@@ -5118,6 +5123,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("120", webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookSiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("FED", webhooks[0].ClientState);
         }
 
         [TestMethod]

--- a/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202209Tests.cs
+++ b/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202209Tests.cs
@@ -3454,6 +3454,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.IsTrue(list.EnableClassicAudienceTargeting);
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("ABC", list.Webhooks[0].ClientState);
 
             // security
             var security = list.Security;
@@ -3754,7 +3755,8 @@ namespace PnP.Framework.Test.Framework.Providers
             list.Webhooks.Add(new PnP.Framework.Provisioning.Model.Webhook
             {
                 ExpiresInDays = 120,
-                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener"
+                ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
+                ClientState = "CBA"
             });
 
             list.IRMSettings = new PnP.Framework.Provisioning.Model.IRMSettings
@@ -4026,6 +4028,7 @@ namespace PnP.Framework.Test.Framework.Providers
 
             Assert.AreEqual(120, list.Webhooks[0].ExpiresInDays);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", list.Webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("CBA", list.Webhooks[0].ClientState);
 
             Assert.IsNotNull(l.Security);
             var security = l.Security.BreakRoleInheritance;
@@ -5168,6 +5171,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual(120, webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("DEF", webhooks[0].ClientState);
         }
 
         [TestMethod]
@@ -5182,7 +5186,8 @@ namespace PnP.Framework.Test.Framework.Providers
             {
                 SiteWebhookType = SiteWebhookType.WebCreated,
                 ServerNotificationUrl = "http://myapp.azurewebsites.net/WebHookListener",
-                ExpiresInDays = 120
+                ExpiresInDays = 120,
+                ClientState = "FED"
             });
 
             var serializer = new TargetSerializer();
@@ -5202,6 +5207,7 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("120", webhooks[0].ExpiresInDays);
             Assert.AreEqual(SiteWebhookSiteWebhookType.WebCreated, webhooks[0].SiteWebhookType);
             Assert.AreEqual("http://myapp.azurewebsites.net/WebHookListener", webhooks[0].ServerNotificationUrl);
+            Assert.AreEqual("FED", webhooks[0].ClientState);
         }
 
         [TestMethod]

--- a/src/lib/PnP.Framework/Extensions/ListExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ListExtensions.cs
@@ -222,8 +222,9 @@ namespace Microsoft.SharePoint.Client
         /// <param name="webHookEndPoint">Url of the web hook service endpoint (the one that will be called during an event)</param>
         /// <param name="expirationDateTime">New web hook expiration date</param>
         /// <param name="accessToken">(optional) The access token to SharePoint</param>
+        /// <param name="clientState">(optional) New web hook client state</param>
         /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
-        public static bool UpdateWebhookSubscription(this List list, string subscriptionId, string webHookEndPoint, DateTime expirationDateTime, string accessToken = null)
+        public static bool UpdateWebhookSubscription(this List list, string subscriptionId, string webHookEndPoint, DateTime expirationDateTime, string accessToken = null, string clientState= null)
         {
             // Get the access from the client context if not specified.
             accessToken = accessToken ?? list.Context.GetAccessToken();
@@ -233,7 +234,7 @@ namespace Microsoft.SharePoint.Client
 
             try
             {
-                return WebhookUtility.UpdateWebhookSubscriptionAsync(list.Context.Url, WebHookResourceType.List, listId.ToString(), subscriptionId, webHookEndPoint, expirationDateTime, accessToken, list.Context as ClientContext).Result;
+                return WebhookUtility.UpdateWebhookSubscriptionAsync(list.Context.Url, WebHookResourceType.List, listId.ToString(), subscriptionId, webHookEndPoint, expirationDateTime, accessToken, list.Context as ClientContext, clientState).Result;
             }
             catch (AggregateException ex)
             {
@@ -250,10 +251,11 @@ namespace Microsoft.SharePoint.Client
         /// <param name="subscriptionId">The id of the subscription to remove</param>
         /// <param name="expirationDateTime">New web hook expiration date</param>
         /// <param name="accessToken">(optional) The access token to SharePoint</param>
+        /// <param name="clientState">(optional) New web hook client state</param>
         /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
-        public static bool UpdateWebhookSubscription(this List list, Guid subscriptionId, DateTime expirationDateTime, string accessToken = null)
+        public static bool UpdateWebhookSubscription(this List list, Guid subscriptionId, DateTime expirationDateTime, string accessToken = null, string clientState = null)
         {
-            return UpdateWebhookSubscription(list, subscriptionId.ToString(), null, expirationDateTime, accessToken);
+            return UpdateWebhookSubscription(list, subscriptionId.ToString(), null, expirationDateTime, accessToken, clientState);
         }
 
         /// <summary>
@@ -265,10 +267,11 @@ namespace Microsoft.SharePoint.Client
         /// <param name="webHookEndPoint">Url of the web hook service endpoint (the one that will be called during an event)</param>
         /// <param name="expirationDateTime">New web hook expiration date</param>
         /// <param name="accessToken">(optional) The access token to SharePoint</param>
+        /// <param name="clientState">(optional) New web hook client state</param>
         /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
-        public static bool UpdateWebhookSubscription(this List list, Guid subscriptionId, string webHookEndPoint, DateTime expirationDateTime, string accessToken = null)
+        public static bool UpdateWebhookSubscription(this List list, Guid subscriptionId, string webHookEndPoint, DateTime expirationDateTime, string accessToken = null, string clientState = null)
         {
-            return UpdateWebhookSubscription(list, subscriptionId.ToString(), webHookEndPoint, expirationDateTime, accessToken);
+            return UpdateWebhookSubscription(list, subscriptionId.ToString(), webHookEndPoint, expirationDateTime, accessToken, clientState);
         }
 
         /// <summary>
@@ -281,7 +284,7 @@ namespace Microsoft.SharePoint.Client
         /// <returns><c>true</c> if the update succeeded, <c>false</c> otherwise</returns>
         public static bool UpdateWebhookSubscription(this List list, WebhookSubscription subscription, string accessToken = null)
         {
-            return UpdateWebhookSubscription(list, subscription.Id, subscription.NotificationUrl, subscription.ExpirationDateTime, accessToken);
+            return UpdateWebhookSubscription(list, subscription.Id, subscription.NotificationUrl, subscription.ExpirationDateTime, accessToken, subscription.ClientState);
         }
 
         /// <summary>

--- a/src/lib/PnP.Framework/Provisioning/Model/SharePoint/Customizations/SiteWebhook.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/SharePoint/Customizations/SiteWebhook.cs
@@ -35,9 +35,10 @@ namespace PnP.Framework.Provisioning.Model
         /// <returns>Returns HashCode</returns>
         public override int GetHashCode()
         {
-            return (String.Format("{0}|{1}|{2}|",
+            return (String.Format("{0}|{1}|{2}|{3}|",
                 ServerNotificationUrl?.GetHashCode() ?? 0,
                 ExpiresInDays.GetHashCode(),
+                ClientState?.GetHashCode() ?? 0,
                 SiteWebhookType.GetHashCode()
             ).GetHashCode());
         }
@@ -57,7 +58,7 @@ namespace PnP.Framework.Provisioning.Model
         }
 
         /// <summary>
-        /// Compares SiteWebhook object based on ServerNotificationUrl, ExpiresInDays, and SiteWebhookType
+        /// Compares SiteWebhook object based on ServerNotificationUrl, ExpiresInDays, ClientState and SiteWebhookType
         /// </summary>
         /// <param name="other">SiteWebhook Class object</param>
         /// <returns>true if the SiteWebhook object is equal to the current object; otherwise, false.</returns>
@@ -70,6 +71,7 @@ namespace PnP.Framework.Provisioning.Model
 
             return (this.ServerNotificationUrl == other.ServerNotificationUrl &&
                 this.ExpiresInDays == other.ExpiresInDays &&
+                this.ClientState == other.ClientState &&
                 this.SiteWebhookType == other.SiteWebhookType
                 );
         }

--- a/src/lib/PnP.Framework/Provisioning/Model/SharePoint/Customizations/Webhook.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/SharePoint/Customizations/Webhook.cs
@@ -22,6 +22,11 @@ namespace PnP.Framework.Provisioning.Model
         /// </remarks>
         public Int32 ExpiresInDays { get; set; }
 
+        /// <summary>
+        /// Defines an opaque string passed back to the client on all notifications, optional attribute.
+        /// </summary>
+        public String ClientState { get; set; }
+
         #endregion
 
         #region Comparison code
@@ -32,9 +37,10 @@ namespace PnP.Framework.Provisioning.Model
         /// <returns>Returns HashCode</returns>
         public override int GetHashCode()
         {
-            return (String.Format("{0}|{1}|",
+            return (String.Format("{0}|{1}|{2}|",
                 ServerNotificationUrl?.GetHashCode() ?? 0,
-                ExpiresInDays.GetHashCode()
+                ExpiresInDays.GetHashCode(),
+                ClientState?.GetHashCode() ?? 0
             ).GetHashCode());
         }
 
@@ -53,7 +59,7 @@ namespace PnP.Framework.Provisioning.Model
         }
 
         /// <summary>
-        /// Compares Webhook object based on ServerNotificationUrl and ExpiresInDays
+        /// Compares Webhook object based on ServerNotificationUrl, ExpiresInDays and ClientState
         /// </summary>
         /// <param name="other">Webhook Class object</param>
         /// <returns>true if the Webhook object is equal to the current object; otherwise, false.</returns>
@@ -65,7 +71,8 @@ namespace PnP.Framework.Provisioning.Model
             }
 
             return (this.ServerNotificationUrl == other.ServerNotificationUrl &&
-                this.ExpiresInDays == other.ExpiresInDays
+                this.ExpiresInDays == other.ExpiresInDays &&
+                this.ClientState == other.ClientState
                 );
         }
 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2060,7 +2060,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     // for a new list immediately add the webhook
                     if (!isListUpdate)
                     {
-                        var webhookSubscription = list.AddWebhookSubscription(webhookServerNotificationUrl, DateTime.Now.AddDays(webhook.ExpiresInDays));
+                        var webhookSubscription = list.AddWebhookSubscription(webhookServerNotificationUrl, DateTime.Now.AddDays(webhook.ExpiresInDays), webhook.ClientState);
                     }
                     // for existing lists add a new webhook or update existing webhook
                     else
@@ -2073,13 +2073,15 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         {
                             // refresh the expiration date of the existing webhook
                             existingWebhook.ExpirationDateTime = DateTime.Now.AddDays(webhook.ExpiresInDays);
+                            // update client state of the existing webhook
+                            existingWebhook.ClientState = webhook.ClientState;
                             // update the existing webhook
                             list.UpdateWebhookSubscription(existingWebhook);
                         }
                         else
                         {
                             // add as new webhook
-                            var webhookSubscription = list.AddWebhookSubscription(webhookServerNotificationUrl, DateTime.Now.AddDays(webhook.ExpiresInDays));
+                            var webhookSubscription = list.AddWebhookSubscription(webhookServerNotificationUrl, DateTime.Now.AddDays(webhook.ExpiresInDays), webhook.ClientState);
                         }
                     }
                 }

--- a/src/lib/PnP.Framework/Utilities/Webhooks/WebhookUtility.cs
+++ b/src/lib/PnP.Framework/Utilities/Webhooks/WebhookUtility.cs
@@ -147,10 +147,11 @@ namespace PnP.Framework.Utilities
         /// <param name="expirationDateTime">New web hook expiration date</param>
         /// <param name="accessToken">Access token to authenticate against SharePoint</param>
         /// <param name="context">ClientContext instance to use for authentication</param>
+        /// <param name="clientState">New web hook client state</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when expiration date is out of valid range.</exception>
         /// <returns>true if succesful, exception in case something went wrong</returns>
         public static async Task<bool> UpdateWebhookSubscriptionAsync(string webUrl, WebHookResourceType resourceType, string resourceId, string subscriptionId,
-            string webHookEndPoint, DateTime expirationDateTime, string accessToken, ClientContext context)
+            string webHookEndPoint, DateTime expirationDateTime, string accessToken, ClientContext context, string clientState = null)
         {
             if (!ValidateExpirationDateTime(expirationDateTime))
                 throw new ArgumentOutOfRangeException(nameof(expirationDateTime), "The specified expiration date is invalid. Should be greater than today and within 6 months");
@@ -182,7 +183,8 @@ namespace PnP.Framework.Utilities
                 {
                     webhookSubscription = new WebhookSubscription()
                     {
-                        ExpirationDateTime = expirationDateTime
+                        ExpirationDateTime = expirationDateTime,
+                        ClientState = clientState
                     };
                 }
                 else
@@ -190,7 +192,8 @@ namespace PnP.Framework.Utilities
                     webhookSubscription = new WebhookSubscription()
                     {
                         NotificationUrl = webHookEndPoint,
-                        ExpirationDateTime = expirationDateTime
+                        ExpirationDateTime = expirationDateTime,
+                        ClientState = clientState
                     };
                 }
 


### PR DESCRIPTION
Webhook ClientState has been part of the Provisioning Schema since 2019-09, but not included in the Models

This Pull Request will cause the ClientState in a PnP Template like this to be applied and not just ignored:

```xml
<?xml version="1.0" encoding="utf-8"?>
<pnp:Provisioning xmlns:pnp="http://schemas.dev.office.com/PnP/2022/09/ProvisioningSchema">
  <pnp:Preferences Generator="Human being" />
  <pnp:Templates ID="CONTAINER-TEMPLATE">
    <pnp:ProvisioningTemplate ID="TEMPLATE" Version="1" BaseSiteTemplate="SITEPAGEPUBLISHING#0" Scope="RootSite">
      <pnp:Lists>
        <pnp:ListInstance ...>
          <pnp:Webhooks>
            <pnp:Webhook ServerNotificationUrl="https://..." ExpiresInDays="90" ClientState="my-important-info" />
          </pnp:Webhooks>
        </pnp:ListInstance>
      </pnp:Lists>
    </pnp:ProvisioningTemplate>
  </pnp:Templates>
</pnp:Provisioning>
```