### PR TITLE
Fixing logging of warnings as informational

### DIFF
--- a/src/lib/PnP.Framework/Diagnostics/TraceLogger.cs
+++ b/src/lib/PnP.Framework/Diagnostics/TraceLogger.cs
@@ -24,7 +24,7 @@ namespace PnP.Framework.Diagnostics
 
         public void Warning(LogEntry entry)
         {
-            Trace.TraceWarning(GetLogEntry(entry, LogLevel.Information));
+            Trace.TraceWarning(GetLogEntry(entry, LogLevel.Warning));
         }
 
         private static string GetLogEntry(LogEntry entry, LogLevel level)


### PR DESCRIPTION
Warnings were being logged as informational instead of warnings. Fixing that here.