### PR TITLE
Allowing the response-type header to be missing

### DIFF
--- a/src/lib/PnP.Framework/Http/HttpClientWebRequestExecutorFactory.cs
+++ b/src/lib/PnP.Framework/Http/HttpClientWebRequestExecutorFactory.cs
@@ -202,7 +202,7 @@ namespace PnP.Framework.Http
 				if (_response == null)
 					throw new InvalidOperationException();
 				_response.Content.Headers.TryGetValues("Content-Type", out var contentType);
-				return contentType.FirstOrDefault();
+				return contentType?.FirstOrDefault();
 			}
 		}
 


### PR DESCRIPTION
Allowing the response-type header to be missing to avoid unclear exceptions. Concrete scenario is when connecting using a Client Secret and doing any basic stuff, such as fetching properties of say a Web, it will throw an exception that the token type (client secret) is not allowed. This response does not have a Content-Type header. This causes a generic exception to be thrown which is far from clear:

<img width="381" alt="image" src="https://github.com/user-attachments/assets/65c89e43-e803-4537-9390-d78c632c8c7a" />

The situation over the wire when this happens is as follows:

<img width="405" alt="image" src="https://github.com/user-attachments/assets/7a51f8ce-6b5f-4bfd-8887-60be098a380e" />

With this fix, at least it gives some indication that the issue is with authorization:

<img width="857" alt="image" src="https://github.com/user-attachments/assets/96cbeff3-915f-449d-8a1a-cc896805dde9" />

I could not get my hands on the actual super clear JSON response to pass with the exception, which would even be nicer, as that seems encapsulated within the native CSOM assembly.