### PR TITLE
Update UsersUtility.cs

### DIFF
--- a/src/lib/PnP.Framework/Graph/UsersUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UsersUtility.cs
@@ -192,11 +192,17 @@ namespace PnP.Framework.Graph
             Dictionary<string, string> additionalHeaders = null;
 
             var requestUrl = $"{GraphHttpClient.GetGraphEndPointUrl(azureEnvironment)}users";
-            var queryStringParams = new List<string>()
-                {
-                    $"$top={(!endIndex.HasValue ? 999 : endIndex.Value >= 999 ? 999 : endIndex.Value)}",
-                    $"$skiptoken={deltaToken}",
-                };
+            var queryStringParams = new List<string>
+            {
+                $"$top={(!endIndex.HasValue ? 999 : endIndex.Value >= 999 ? 999 : endIndex.Value)}"
+            };
+
+            // Add $skiptoken only if deltaToken is not null or empty
+            if (!string.IsNullOrEmpty(deltaToken))
+            {
+                queryStringParams.Add($"$skiptoken={deltaToken}");
+            }
+
             if (propertiesToSelect.Count > 0)
             {
                 queryStringParams.Add("$select=" + string.Join(",", propertiesToSelect));


### PR DESCRIPTION
This PR introduces a change to the ListUserDelta method to ensure that the $skiptoken query parameter is only included in the request if the deltaToken parameter is not null or empty. This change addresses scenarios where the deltaToken is not provided, ensuring the query string remains valid and avoids unnecessary parameters.

#1156 