### PR TITLE
Fix potential NPE when targetclientcontext is null

### DIFF
--- a/src/lib/PnP.Framework/Modernization/Transform/PageTransformator.cs
+++ b/src/lib/PnP.Framework/Modernization/Transform/PageTransformator.cs
@@ -293,7 +293,10 @@ namespace PnP.Framework.Modernization.Transform
                         }
                     }
 
-                    LogInfo($"{targetClientContext.Web.GetUrl()}", LogStrings.Heading_Summary, LogEntrySignificance.TargetSiteUrl);
+                    if (hasTargetContext)
+                    {
+                        LogInfo($"{targetClientContext.Web.GetUrl()}", LogStrings.Heading_Summary, LogEntrySignificance.TargetSiteUrl);
+                    }
                 }
 
                 PopulateGlobalProperties(sourceClientContext, targetClientContext);


### PR DESCRIPTION
When sourceClientContext.Site.Id.Equals(targetClientContext.Site.Id)), targetclientcontext will be set to null. which casue 
`                        LogInfo($"{targetClientContext.Web.GetUrl()}", LogStrings.Heading_Summary, LogEntrySignificance.TargetSiteUrl);
` throw NPE