### PR TITLE
Safely handle null footer DisplayName in ProvisionObjects to avoid REST API failure

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -46,7 +46,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     var chrome = pnpCoreContext.Web.GetBrandingManager().GetChromeOptions();
 
                     footer.Enabled = chrome.Footer.Enabled;
-                    footer.DisplayName = chrome.Footer.DisplayName;
+                    // Avoid setting a null DisplayName, which causes errors if the footer was previously enabled.
+                    // This can happen when a user disables the footer after it was set.
+                    // Only update if DisplayName is present in the template.
+                    if (template.Footer.DisplayName != null)
+                    {
+                        chrome.Footer.DisplayName = template.Footer.DisplayName;
+                    }
                     footer.Layout = (PnP.Framework.Provisioning.Model.SiteFooterLayout)Enum.Parse(typeof(PnP.Framework.Provisioning.Model.SiteFooterLayout), chrome.Footer.Layout.ToString());
                     footer.BackgroundEmphasis = (PnP.Framework.Provisioning.Model.Emphasis)Enum.Parse(typeof(PnP.Framework.Provisioning.Model.Emphasis), chrome.Footer.Emphasis.ToString());
                 }


### PR DESCRIPTION
**Overview**
This pull request improves how we handle the Chrome.Footer.DisplayName property in the ProvisionObjects method when applying site footer settings using a provisioning template.

**🧩 Problem**
When provisioning an existing site collection where a user had:

Enabled the site footer, and then

Later disabled it manually in SharePoint,

…the XML template (ProvisioningTemplate) still includes a <Footer> node but omits the DisplayName property — making template.Footer.DisplayName null.

If we try to update the footer using SetChromeOptionsAsync() and attempt to set the DisplayName to null (overwriting an existing non-null value or empty string), SharePoint throws a 500 Internal Server Error.

**Stack Trace:**
HttpResponseCode: 500
Code: Microsoft.SharePoint.Navigation.REST.NavigationServiceException
Message: An unexpected error occurred

PnP.Core.SharePointRestServiceException: SharePoint Rest service exception
   at PnP.Core.Services.BatchClient.ProcessSharePointRestBatchResponseContent(...)
   ...
   at PnP.Core.Model.SharePoint.BrandingManager.SetChromeOptionsAsync(...)
   at PnP.Framework.Provisioning.ObjectHandlers.ObjectSiteFooterSettings.ProvisionObjects(...) 


This ensures we only set the DisplayName if it is present in the provisioning template, avoiding the invalid transition and the resulting SharePoint REST API error.
