### PR TITLE
Fix object list instance data rows create row faild without log message

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -40,7 +40,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ListInstancesDataRows_Processing_data_rows_for__0_, listInstance.Title);
                         // Retrieve the target list
                         var list = web.GetListByUrl(parser.ParseString(listInstance.Url));
-                        web.Context.Load(list);
+                        web.Context.Load(list, l => l.Id, l=>l.BaseType, l=>l.RootFolder);
 
                         // Retrieve the fields' types from the list
                         Microsoft.SharePoint.Client.FieldCollection fields = list.Fields;
@@ -198,6 +198,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                                     WriteMessage(warning, ProvisioningMessageType.Warning);
                                     continue;
                                 }
+                                scope.LogError(CoreResources.Provisioning_ObjectHandlers_ListInstancesDataRows_Creating_listitem_failed___0_____1_, ex.Message, ex.StackTrace);
+                                throw;
                             }
                             catch (Exception ex)
                             {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstanceDataRows.cs
@@ -40,7 +40,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                         scope.LogDebug(CoreResources.Provisioning_ObjectHandlers_ListInstancesDataRows_Processing_data_rows_for__0_, listInstance.Title);
                         // Retrieve the target list
                         var list = web.GetListByUrl(parser.ParseString(listInstance.Url));
-                        web.Context.Load(list, l => l.Id, l=>l.BaseType, l=>l.RootFolder);
+                        web.Context.Load(list, l => l.Id, l => l.Title, l=>l.BaseType, l=>l.RootFolder);
 
                         // Retrieve the fields' types from the list
                         Microsoft.SharePoint.Client.FieldCollection fields = list.Fields;

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.SharePoint.Client;
+using Microsoft.SharePoint.Client;
 using Newtonsoft.Json;
 using PnP.Framework.Diagnostics;
 using PnP.Framework.Provisioning.Model;
@@ -46,7 +46,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     var chrome = pnpCoreContext.Web.GetBrandingManager().GetChromeOptions();
 
                     footer.Enabled = chrome.Footer.Enabled;
-                    footer.DisplayName = chrome.Footer.DisplayName;
+                    // Avoid setting a null DisplayName, which causes errors if the footer was previously enabled.
+                    // This can happen when a user disables the footer after it was set.
+                    // Only update if DisplayName is present in the template.
+                    if (template?.Footer?.DisplayName != null)
+                    {
+                        chrome.Footer.DisplayName = template.Footer.DisplayName;
+                    }
                     footer.Layout = (PnP.Framework.Provisioning.Model.SiteFooterLayout)Enum.Parse(typeof(PnP.Framework.Provisioning.Model.SiteFooterLayout), chrome.Footer.Layout.ToString());
                     footer.BackgroundEmphasis = (PnP.Framework.Provisioning.Model.Emphasis)Enum.Parse(typeof(PnP.Framework.Provisioning.Model.Emphasis), chrome.Footer.Emphasis.ToString());
                 }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -304,7 +304,15 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 // Otherwise, ensure the property is loaded
                 try
                 {
-                    isPagesLib = list.EnsureProperty(l => l.RootFolder.Name).Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
+                    if(!list.IsObjectPropertyInstantiated("RootFolder"))
+                    {
+                        list.EnsureProperty(l => l.RootFolder);
+                    }
+                    if (!list.RootFolder.IsPropertyAvailable("Name"))
+                    {
+                        list.RootFolder.EnsureProperty(rf => rf.Name);
+                    }
+                    isPagesLib = list.RootFolder.Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
                 }
                 catch (Exception ex)
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -290,7 +290,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(Constants.LOGGING_SOURCE, "Error while trying to get list property 'BaseType' for {0}. Error: {1}", list.Title, ex.Message);
+                    Log.Error(Constants.LOGGING_SOURCE, "Error while trying to get list property 'BaseType' for '{0}'. Error: {1}", list.IsPropertyAvailable("Title")?list.Title:"list title not loaded", ex.Message);
                     //throw;
                 }
             }
@@ -308,7 +308,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(Constants.LOGGING_SOURCE, "Error while trying to get list property 'RootFolder' for {0}. Error: {1}", list.Title, ex.Message);
+                    Log.Error(Constants.LOGGING_SOURCE, "Error while trying to get list property 'RootFolder' for '{0}'. Error: {1}", list.IsPropertyAvailable("Title") ? list.Title : "list title not loaded", ex.Message);
                     //throw;
                 }
             }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -269,7 +269,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             var list = item.ParentList;
 
             //Ensure can have unwanted sideeffects as ExecuteQuery is called..
-            if (!context.Web.IsObjectPropertyInstantiated(w => w.Url))
+            if (!context.Web.IsPropertyAvailable("Url"))
             {
                 context.Web.EnsureProperty(w => w.Url);
             }
@@ -277,9 +277,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             bool isDocLib = false;  
             bool isPagesLib = false;
 
-            if (list.IsObjectPropertyInstantiated(l => l.BaseType))
+            if (list.IsPropertyAvailable("BaseType"))
             {
-                // If BaseType is already loaded, use it directly
                 isDocLib = list.BaseType == BaseType.DocumentLibrary;
             }
             else
@@ -288,7 +287,6 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 try
                 {
                     isDocLib = list.EnsureProperty(l => l.BaseType) == BaseType.DocumentLibrary;
-
                 }
                 catch (Exception ex)
                 {
@@ -297,9 +295,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 }
             }
 
-            if (list.IsObjectPropertyInstantiated(l => l.RootFolder))
+            if (list.IsObjectPropertyInstantiated("RootFolder") && list.RootFolder.IsPropertyAvailable("Name"))
             {
-                // If BaseType is already loaded, use it directly
                 isPagesLib = list.RootFolder.Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
             }
             else
@@ -307,7 +304,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 // Otherwise, ensure the property is loaded
                 try
                 {
-                    isPagesLib = list.EnsureProperty(l => l.RootFolder).Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
+                    isPagesLib = list.EnsureProperty(l => l.RootFolder.Name).Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
                 }
                 catch (Exception ex)
                 {

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ListItemUtilities.cs
@@ -267,10 +267,54 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
 
             var context = item.Context as ClientContext;
             var list = item.ParentList;
-            context.Web.EnsureProperty(w => w.Url);
 
-            bool isDocLib = list.EnsureProperty(l => l.BaseType) == BaseType.DocumentLibrary;
-            bool isPagesLib = list.EnsureProperty(l => l.RootFolder).Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
+            //Ensure can have unwanted sideeffects as ExecuteQuery is called..
+            if (!context.Web.IsObjectPropertyInstantiated(w => w.Url))
+            {
+                context.Web.EnsureProperty(w => w.Url);
+            }
+
+            bool isDocLib = false;  
+            bool isPagesLib = false;
+
+            if (list.IsObjectPropertyInstantiated(l => l.BaseType))
+            {
+                // If BaseType is already loaded, use it directly
+                isDocLib = list.BaseType == BaseType.DocumentLibrary;
+            }
+            else
+            {
+                // Otherwise, ensure the property is loaded
+                try
+                {
+                    isDocLib = list.EnsureProperty(l => l.BaseType) == BaseType.DocumentLibrary;
+
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(Constants.LOGGING_SOURCE, "Error while trying to get list property 'BaseType' for {0}. Error: {1}", list.Title, ex.Message);
+                    //throw;
+                }
+            }
+
+            if (list.IsObjectPropertyInstantiated(l => l.RootFolder))
+            {
+                // If BaseType is already loaded, use it directly
+                isPagesLib = list.RootFolder.Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
+            }
+            else
+            {
+                // Otherwise, ensure the property is loaded
+                try
+                {
+                    isPagesLib = list.EnsureProperty(l => l.RootFolder).Name.Equals("SitePages", StringComparison.InvariantCultureIgnoreCase);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(Constants.LOGGING_SOURCE, "Error while trying to get list property 'RootFolder' for {0}. Error: {1}", list.Title, ex.Message);
+                    //throw;
+                }
+            }
 
             var clonedContext = context.Clone(context.Web.Url);
             var web = clonedContext.Web;


### PR DESCRIPTION
@jansenbe 
There is a issue spreading across Tenants where the default properties loaded in CSOM for List and Libraries have changed. 
For some Tenants it has been there last week but gone after weekend - not quite sure if bug or change.

Anyway - up to now it seems when happen that:
Load of RootFolder for Libraries still loads the Attribute Name, but not for Lists
That BaseType is still loaded for Lists but not Libraries  

Along with this fix, the already merged PR1161 for Footer did not take into consideration that Footer can be null