### PR TITLE
RequestStream creation before refering to it

### DIFF
--- a/src/lib/PnP.Framework/Http/HttpClientWebRequestExecutorFactory.cs
+++ b/src/lib/PnP.Framework/Http/HttpClientWebRequestExecutorFactory.cs
@@ -129,6 +129,7 @@ namespace PnP.Framework.Http
 			{
 				_request.Headers.UserAgent.ParseAdd(_webRequest.UserAgent);
 			}
+            _requestStream = new RequestStream(GetRequestStream());
 			_requestStream.Seek(0, SeekOrigin.Begin);
 			_request.Content = new StreamContent(_requestStream);
 			if (MediaTypeHeaderValue.TryParse(_requestContentType, out var parsedValue))


### PR DESCRIPTION
After a change in AuthenticationManager, which is using ClientContext extension to add WebRequestExecutorFactory, HTTP requests are failing with null reference exception, as _requestStream was never initialized and .Seek method is failing to execute. Added instance creation before executing seek method