### PR TITLE
Add null check before assigning footer display name from template

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectSiteFooterSettings.cs
@@ -49,7 +49,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     // Avoid setting a null DisplayName, which causes errors if the footer was previously enabled.
                     // This can happen when a user disables the footer after it was set.
                     // Only update if DisplayName is present in the template.
-                    if (template.Footer.DisplayName != null)
+                    if (template.Footer?.DisplayName != null)
                     {
                         chrome.Footer.DisplayName = template.Footer.DisplayName;
                     }


### PR DESCRIPTION
This PR improves a previous implementation by ensuring that chrome.Footer.DisplayName is only set when template.Footer.DisplayName is not null.

✅ Changes:

Added a null check before assigning the DisplayName from the template to the chrome footer.

📌 Purpose:

To prevent potential NullReferenceExceptions and make the code more robust when handling optional template values.

🔄 Context:

This update enhances a prior pull request by adding a null safety check that was previously missing.

Oldest PR: https://github.com/pnp/pnpframework/pull/1161