### PR TITLE
Extract Collapsible and DisplayName properties of page sections

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -216,6 +216,8 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                         {
                             Order = section.Order,
                             BackgroundEmphasis = (Emphasis)section.ZoneEmphasis,
+                            Collapsible = section.Collapsible,
+                            DisplayName = section.DisplayName
                         };
                         if (section.VerticalSectionColumn != null)
                         {


### PR DESCRIPTION
Currently, extracting pages does not extract the "DisplayName" or "Collapsible" property of sections.

See issue #1175 