### PR TITLE
Fix Graph group serialization.

### DIFF
--- a/src/lib/PnP.Framework/Graph/Model/GroupExtended.cs
+++ b/src/lib/PnP.Framework/Graph/Model/GroupExtended.cs
@@ -15,6 +15,7 @@ namespace PnP.Framework.Graph.Model
         public List<GroupLabel> AssignedLabels { get; set; }
         public string PreferredDataLocation { get; set; }
 
+        [JsonExtensionData]
         public Dictionary<string, object> AdditionalData { get; set; }
     }
 }


### PR DESCRIPTION
Fixes a Graph Group serialization issue introduced in #1003.
Without this a 400 Bad Request was returned from Graph when creating a new Group, e.g. during provisioning with app credentials.