### PR TITLE
Catch unauthorized exception when getting tenant themes.

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectHierarchySequenceSites.cs
@@ -256,9 +256,16 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     ClientObjectList<Microsoft.Online.SharePoint.TenantManagement.ThemeProperties> tenantThemes = null;
                     if (TenantExtensions.IsCurrentUserTenantAdmin((ClientContext)tenant.Context))
                     {
-                        tenantThemes = tenant.GetAllTenantThemes();
-                        tenant.Context.Load(tenantThemes);
-                        tenant.Context.ExecuteQueryRetry();
+                        try
+                        {
+                            tenantThemes = tenant.GetAllTenantThemes();
+                            tenant.Context.Load(tenantThemes);
+                            tenant.Context.ExecuteQueryRetry();
+                        }
+                        catch (ServerUnauthorizedAccessException)
+                        {
+                            WriteMessage("Unauthorized getting tenant themes so skipping.", ProvisioningMessageType.Warning);
+                        }
                     }
 
                     foreach (var sitecollection in sequence.SiteCollections)


### PR DESCRIPTION
In some cases the app credentials would pass the tenant admin check but still not have access to the tenant themes and an unauthorized exception would be thrown, e.g. with Group.ReadWrite.All and Group.Create permissions.