### PR TITLE
Added EnsureAndSetUserFields method to ClientContextExtensions

### DIFF
--- a/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
@@ -1158,6 +1158,56 @@ namespace Microsoft.SharePoint.Client
             return await SiteCollection.DeleteSiteAsync(clientContext);
         }
 
+        /// <summary>
+        /// Safely assigns user email addresses to SharePoint list item user fields with automatic user resolution and error handling
+        /// </summary>
+        /// <param name="ctx">The SharePoint client context for executing operations</param>
+        /// <param name="item">The target list item to update with user field assignments</param>
+        /// <param name="fieldAssignments">Collection of field-email pairs where Field is the internal field name and Email is the user's email address</param>
+        /// <param name="clearIfNullOrWhiteSpace">If true, clears the field when email is null/empty; if false, skips the assignment</param>
+        /// <remarks>
+        /// This method queues operations using ExceptionHandlingScope but does not execute them.
+        /// The caller must call ctx.ExecuteQueryRetry() after this method to execute the queued operations.
+        /// Multiple calls can be batched together before executing.
+        /// </remarks>
+        public static void EnsureAndSetUserFields(
+            this ClientContext ctx,
+            ListItem item,
+            IEnumerable<(string Field, string Email)> fieldAssignments,
+            bool clearIfNullOrWhiteSpace)
+        {
+            foreach (var (field, email) in fieldAssignments)
+            {
+                if (string.IsNullOrWhiteSpace(email))
+                {
+                    if (clearIfNullOrWhiteSpace)
+                    {
+                        item[field] = null;
+                        item.Update();
+                    }
+
+                    continue;
+                }
+
+                var scope = new ExceptionHandlingScope(ctx);
+                using (scope.StartScope())
+                {
+                    using (scope.StartTry())
+                    {
+                        item[field] = FieldUserValue.FromUser(email);
+                        item.Update();
+                    }
+
+                    using (scope.StartCatch())
+                    {
+                        ctx.Web.EnsureUser(email);
+                        item[field] = FieldUserValue.FromUser(email);
+                        item.Update();
+                    }
+                }
+            }
+        }
+
         internal static CookieContainer GetAuthenticationCookies(this ClientContext context)
         {
             var authCookiesContainer = context.GetContextSettings()?.AuthenticationManager.CookieContainer;


### PR DESCRIPTION
### Summary
Adds a new extension method `EnsureAndSetUserFields` to `ClientContext` that provides safe assignment of user email addresses to SharePoint list item user fields with automatic user resolution and error handling.

### Changes
- **Added**: `EnsureAndSetUserFields` extension method to `ClientContextExtensions.cs`
- **Features**:
  - Automatic user resolution using `ExceptionHandlingScope` for robust error handling
  - Supports batch operations for multiple field-email assignments
  - Configurable null/whitespace handling behavior
  - Follows CSOM queuing pattern (requires caller to execute operations)
`
ctx.EnsureAndSetUserFields(listItem, fieldAssignments, true);
`
`
ctx.ExecuteQueryRetry();
`

### Usage
`
var fieldAssignments = new[] { ("AssignedTo", "user1@contoso.com"), ("Author", "user2@contoso.com") };
`
`
ctx.EnsureAndSetUserFields(listItem, fieldAssignments, clearIfNullOrWhiteSpace: true); 
`
`ctx.ExecuteQueryRetry();`

### Breaking Changes
None - this is a new addition that doesn't affect existing functionality.