### PR TITLE
Update path handling for cross-platform compatibility

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Connectors/FileSystemConnector.cs
+++ b/src/lib/PnP.Framework/Provisioning/Connectors/FileSystemConnector.cs
@@ -39,7 +39,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             this.AddParameterAsString(CONNECTIONSTRING, connectionString);
             this.AddParameterAsString(CONTAINER, container);
@@ -68,7 +69,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             List<string> result = new List<string>();
 
@@ -102,7 +104,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             List<string> result = new List<string>();
 
@@ -153,7 +156,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             string result = null;
             MemoryStream stream = null;
@@ -206,7 +210,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             return GetFileFromStorage(fileName, container);
         }
@@ -238,7 +243,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             if (stream == null)
             {
@@ -292,7 +298,8 @@ namespace PnP.Framework.Provisioning.Connectors
             {
                 container = "";
             }
-            container = container.Replace('/', '\\');
+            container = container.Replace('/', Path.DirectorySeparatorChar)
+                                 .Replace('\\', Path.DirectorySeparatorChar);
 
             try
             {
@@ -349,9 +356,9 @@ namespace PnP.Framework.Provisioning.Connectors
         {
             string filePath = "";
 
-            if (container.IndexOf(@"\") > 0)
+            if (container.IndexOf(Path.DirectorySeparatorChar) > 0)
             {
-                string[] parts = container.Split(new string[] { @"\" }, StringSplitOptions.RemoveEmptyEntries);
+                string[] parts = container.Split(new[] { Path.DirectorySeparatorChar }, StringSplitOptions.RemoveEmptyEntries);
                 filePath = Path.Combine(GetConnectionString(), parts[0]);
 
                 if (parts.Length > 1)

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/FileUtilities.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/FileUtilities.cs
@@ -11,7 +11,6 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
 {
     public static class FileUtilities
     {
-
         public static Stream GetFileStream(ProvisioningTemplate template, Model.File file)
         {
             return GetFileStream(template, file.Src);
@@ -24,9 +23,10 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             var container = String.Empty;
             if (fileName.Contains(@"\") || fileName.Contains(@"/"))
             {
-                var tempFileName = fileName.Replace(@"/", @"\");
-                container = fileName.Substring(0, tempFileName.LastIndexOf(@"\"));
-                fileName = fileName.Substring(tempFileName.LastIndexOf(@"\") + 1);
+                var tempFileName = fileName.Replace('/', Path.DirectorySeparatorChar)
+                                           .Replace('\\', Path.DirectorySeparatorChar);
+                container = fileName.Substring(0, tempFileName.LastIndexOf(Path.DirectorySeparatorChar));
+                fileName = fileName.Substring(tempFileName.LastIndexOf(Path.DirectorySeparatorChar) + 1);
             }
 
             // add the default provided container (if any)
@@ -38,7 +38,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                     {
                         container = container.TrimStart("/".ToCharArray());
                     }
-                    container = $@"{template.Connector.GetContainer()}\{container}";
+                    container = Path.Combine(template.Connector.GetContainer(), container);
                 }
             }
             else
@@ -67,7 +67,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             string folderToGrabFilesFrom = directory.Src;
             if (!String.IsNullOrEmpty(directory.ParentTemplate.Connector.GetContainer()))
             {
-                folderToGrabFilesFrom = directory.ParentTemplate.Connector.GetContainer() + @"\" + directory.Src;
+                folderToGrabFilesFrom = Path.Combine(directory.ParentTemplate.Connector.GetContainer(), directory.Src);
             }
 
             var files = directory.ParentTemplate.Connector.GetFiles(folderToGrabFilesFrom);
@@ -85,13 +85,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             }
 
             result.AddRange(from file in files
+                            let filePath = Path.Combine(directory.Src, file)
                             select new Model.File(
-                                directory.Src + @"\" + file,
+                                filePath,
                                 directory.Folder,
                                 directory.Overwrite,
                                 null, // No WebPartPages are supported with this technique
-                                metadataProperties != null && metadataProperties.ContainsKey(directory.Src + @"\" + file) ?
-                                    metadataProperties[directory.Src + @"\" + file] : null,
+                                metadataProperties != null && metadataProperties.ContainsKey(filePath) ?
+                                    metadataProperties[filePath] : null,
                                 directory.Security,
                                 directory.Level
                                 ));
@@ -102,14 +103,14 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                 var parentFolder = directory;
                 foreach (var folder in subFolders)
                 {
-                    directory.Src = parentFolder.Src + @"\" + folder;
-                    directory.Folder = parentFolder.Folder + @"\" + folder;
+                    directory.Src = Path.Combine(parentFolder.Src, folder);
+                    directory.Folder = Path.Combine(parentFolder.Folder, folder);
 
                     result.AddRange(directory.GetDirectoryFiles(metadataProperties));
 
                     //Remove the subfolder path(added above) as the second subfolder should come under its parent folder and not under its sibling
-                    parentFolder.Src = parentFolder.Src.Substring(0, parentFolder.Src.LastIndexOf(@"\"));
-                    parentFolder.Folder = parentFolder.Folder.Substring(0, parentFolder.Folder.LastIndexOf(@"\"));
+                    parentFolder.Src = parentFolder.Src.Substring(0, parentFolder.Src.LastIndexOf(Path.DirectorySeparatorChar));
+                    parentFolder.Folder = parentFolder.Folder.Substring(0, parentFolder.Folder.LastIndexOf(Path.DirectorySeparatorChar));
                 }
             }
 


### PR DESCRIPTION
Replaced hardcoded path separators with Path.DirectorySeparatorChar and Path.Combine in provisioning file system connector and file utilities.
This fixes an issue where the provisioning file handler would fail when recursively copying files on Linux.