### PR TITLE
extend CanvasSection Model with HeadingLevel for collapsible-section-tilte

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Model/SharePoint/ModernExperiences/CanvasSection.cs
+++ b/src/lib/PnP.Framework/Provisioning/Model/SharePoint/ModernExperiences/CanvasSection.cs
@@ -71,6 +71,10 @@ namespace PnP.Framework.Provisioning.Model
         /// </summary>
         public bool ShowDividerLine { get; set; }
 
+        /// <summary>
+        /// Defines Heading Level for collapsible Canvas Section Title of a Client-side Page.
+        /// </summary>
+        public int HeadingLevel { get; set; }
         #endregion
 
         #region Constructors
@@ -93,7 +97,7 @@ namespace PnP.Framework.Provisioning.Model
         /// <returns>Returns HashCode</returns>
         public override int GetHashCode()
         {
-            return (String.Format("{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}|{8}|{9}|",
+            return (String.Format("{0}|{1}|{2}|{3}|{4}|{5}|{6}|{7}|{8}|{9}|{10}|",
                 this.Controls.Aggregate(0, (acc, next) => acc += (next != null ? next.GetHashCode() : 0)),
                 Order.GetHashCode(),
                 Type.GetHashCode(),
@@ -103,7 +107,8 @@ namespace PnP.Framework.Provisioning.Model
                 (this.DisplayName != null ? this.DisplayName.GetHashCode() : 0),
                 this.IsExpanded.GetHashCode(),
                 this.IconAlignment.GetHashCode(),
-                this.ShowDividerLine.GetHashCode()
+                this.ShowDividerLine.GetHashCode(),
+                this.HeadingLevel.GetHashCode()
             ).GetHashCode());
         }
 
@@ -142,7 +147,8 @@ namespace PnP.Framework.Provisioning.Model
                 this.DisplayName == other.DisplayName &&
                 this.IsExpanded == other.IsExpanded &&
                 this.IconAlignment == other.IconAlignment &&
-                this.ShowDividerLine == other.ShowDividerLine
+                this.ShowDividerLine == other.ShowDividerLine &&
+                this.HeadingLevel == other.HeadingLevel
                 );
         }
 

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectClientSidePages.cs
@@ -507,6 +507,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                             typeof(PnP.Core.Model.SharePoint.IconAlignment), 
                             section.IconAlignment.ToString());
                         targetSection.ShowDividerLine = section.ShowDividerLine;
+                        //XML-Schema does not support HeadingLevel-Value, so we need to get it from JsonControlData if not set through code manually
+                        if (section.HeadingLevel == 0)
+                        {
+                            SetSectionHeadingLevel(section);
+                        }
+                        if( section.HeadingLevel > 0)
+                            targetSection.HeadingLevel = section.HeadingLevel;
                     }
 
                     // Add controls to the section
@@ -1101,6 +1108,20 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     {
                         canvasColumn.ZoneReflowStrategy = PnPCore.ZoneReflowStrategy.LeftToRight;
                     }
+                }
+            }
+        }
+
+        private static void SetSectionHeadingLevel(CanvasSection section)
+        {
+            var control = section.Controls.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p.JsonControlData) && p.JsonControlData.ToLower().Contains("headinglevel"));
+            if (control != null)
+            {
+                var json = JsonConvert.DeserializeObject<JObject>(control.JsonControlData);
+                var headingLevel = json.SelectToken("zoneGroupMetadata.headingLevel")?.Value<int>();
+                if (headingLevel.HasValue)
+                {
+                    section.HeadingLevel = headingLevel.Value;
                 }
             }
         }


### PR DESCRIPTION
as XML-Template does not support this property, we get it from Control.JsonControlData -> zoneGroupMetadata.headingLevel in case it's not specified in a other way through code