### PR TITLE
Fix for conflict detection when updating teams

### DIFF
--- a/src/lib/PnP.Framework/Utilities/Graph/GraphHelper.cs
+++ b/src/lib/PnP.Framework/Utilities/Graph/GraphHelper.cs
@@ -81,7 +81,8 @@ namespace PnP.Framework.Utilities.Graph
                 if (!string.IsNullOrEmpty(alreadyExistsErrorMessage) &&
                     !string.IsNullOrEmpty(matchingFieldName) &&
                     !string.IsNullOrEmpty(matchingFieldValue) &&
-                    ex.InnerException.Message.Contains(alreadyExistsErrorMessage))
+                    (ex.InnerException?.Message.Contains(alreadyExistsErrorMessage) == true ||
+                     ex.InnerException?.InnerException?.Message.Contains(alreadyExistsErrorMessage) == true))
                 {
                     try
                     {


### PR DESCRIPTION
This fixes an issue that occurs when updating an existing team during provisioning. Microsoft have changed the way Graph returns a Conflict error when the team exists and this adds a check for the new way.

Fixes #1205 