### PR TITLE
1231 client side pages wrong vertical section column index

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -283,9 +283,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                             foreach (var control in column.Controls)
                             {
                                 // Create control
+                                // For vertical section columns, always use section.Columns.Count as the column index.
+                                // The vertical column is always created last by CanvasSection constructor during import,
+                                // but during export (HTML parsing) it may appear at any position in the Columns list
+                                // depending on HTML control ordering.
                                 CanvasControl controlInstance = new CanvasControl()
                                 {
-                                    Column = column.IsVerticalSectionColumn ? section.Columns.IndexOf(column) + 1 : column.Order,
+                                    Column = column.IsVerticalSectionColumn ? section.Columns.Count : column.Order,
                                     ControlId = control.InstanceId,
                                     Order = control.Order,
                                 };


### PR DESCRIPTION
# Fix: Provisioning Engine (Client-Side Pages) — Vertical section controls exported with wrong Column index #1231 

## Summary

Fixes a bug where controls in vertical section columns are exported with an incorrect `Column` index in PnP provisioning templates. This causes the controls to be placed in the wrong column (e.g. the narrow left column instead of the vertical section) when the template is applied to a new site.

## Problem

In `ClientSidePageContentsHelper.cs`, the column index for vertical section controls during template export is computed using:

```csharp
Column = column.IsVerticalSectionColumn ? section.Columns.IndexOf(column) + 1 : column.Order
```

The `Columns` list is populated from HTML parsing, so the vertical section column (layoutIndex=2) can appear at any position — including index 0. This means `section.Columns.IndexOf(column) + 1` could return `1` for the vertical column.

During **import** (`ObjectClientSidePages.cs`), the `CanvasSection` constructor creates columns in a fixed order. For `TwoColumnRightVerticalSection`:
1. Narrow column (columnFactor=4)
2. Wide column (columnFactor=8)
3. Vertical section column (columnFactor=12)

Controls are placed using `page.Sections[sectionCount].Columns[control.Column - 1]`, so `Column=1` maps to the narrow column — not the intended vertical section.

## Fix

Changed the vertical section column index to use `section.Columns.Count`, which always matches the last position where the import creates the vertical column:

```diff
- Column = column.IsVerticalSectionColumn ? section.Columns.IndexOf(column) + 1 : column.Order,
+ Column = column.IsVerticalSectionColumn ? section.Columns.Count : column.Order,
```

This is correct because:
- The `CanvasSection` constructor always creates the vertical section column **last**
- `Columns.Count` produces the 1-based index of the last column
- This value is stable regardless of HTML parsing order during export

## File changed

- `src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs` — Control export logic (around line 291)

## Testing

- Verified with the `Employee-onboarding-team-home.aspx` page from the standard SharePoint **Employee onboarding** team site template, which uses a `TwoColumnRightVerticalSection` layout with News, Events, People, and Spacer web parts in the vertical section
- Before fix: Vertical section controls exported with `Column="1"`, placed in narrow left column during provisioning
- After fix: Controls correctly exported with `Column="3"` (matching the vertical section position), page layout matches the source after provisioning

## Related

- There is a companion fix in pnp/pnpcore for section type detection of vertical sections (`Page.cs`)
- Both bugs are caused by the same root issue: assumptions about HTML parsing order determining column positions in the `Columns` list
