### PR TITLE
Fix OneColumnVerticalSection mangled to OneColumn on template save

### DIFF
--- a/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202209Tests.cs
+++ b/src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202209Tests.cs
@@ -5445,5 +5445,94 @@ namespace PnP.Framework.Test.Framework.Providers
             Assert.AreEqual("user1@contoso.com", page.Security.BreakRoleInheritance.RoleAssignment[0].Principal);
             Assert.AreEqual("Full Control", page.Security.BreakRoleInheritance.RoleAssignment[0].RoleDefinition);
         }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void XMLSerializer_RoundTrip_ClientSidePage_OneColumnVerticalSection_WithCallToActionControls()
+        {
+            var templateXml = @"<pnp:Provisioning xmlns:pnp=""http://schemas.dev.office.com/PnP/2022/09/ProvisioningSchema"">
+  <pnp:Templates>
+    <pnp:ProvisioningTemplate ID=""TEMPLATE-ISSUE-1206"">
+      <pnp:ClientSidePages>
+        <pnp:ClientSidePage PageName=""Issue1206.aspx"" Overwrite=""true"">
+          <pnp:Sections>
+            <pnp:Section Order=""1"" Type=""OneColumnVerticalSection"" VerticalSectionEmphasis=""Soft"">
+              <pnp:Controls>
+                <pnp:CanvasControl WebPartType=""CallToAction"" JsonControlData=""{&quot;position&quot;:{&quot;sectionFactor&quot;:100}}"" ControlId=""df8e44e7-edd5-46d5-90da-aca1539313b8"" Order=""1"" Column=""1"" />
+                <pnp:CanvasControl WebPartType=""Custom"" CustomWebPartName=""Custom web part"" JsonControlData=""{}"" ControlId=""7a8004cb-8a1d-4fee-831d-2780ba29554c"" Order=""1"" Column=""2"" />
+              </pnp:Controls>
+            </pnp:Section>
+          </pnp:Sections>
+        </pnp:ClientSidePage>
+      </pnp:ClientSidePages>
+    </pnp:ProvisioningTemplate>
+  </pnp:Templates>
+</pnp:Provisioning>";
+
+            var provider = new XMLFileSystemTemplateProvider(".", "");
+            var serializer = new TargetSerializer();
+            serializer.Initialize(provider);
+
+            using (var inputStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(templateXml)))
+            {
+                var template = serializer.ToProvisioningTemplate(inputStream);
+                var modelSection = template.ClientSidePages[0].Sections[0];
+
+                Assert.AreEqual(CanvasSectionType.OneColumnVerticalSection, modelSection.Type);
+                Assert.AreEqual(2, modelSection.Controls[1].Column);
+
+                using (var outputStream = serializer.ToFormattedTemplate(template))
+                {
+                    var xml = XDocument.Load(outputStream);
+                    XNamespace pnp = "http://schemas.dev.office.com/PnP/2022/09/ProvisioningSchema";
+                    var section = xml.Descendants(pnp + "Section").Single();
+                    var controls = section.Descendants(pnp + "CanvasControl").ToList();
+
+                    Assert.AreEqual("OneColumnVerticalSection", section.Attribute("Type")?.Value);
+                    Assert.AreEqual("2", controls[1].Attribute("Column")?.Value);
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory(TEST_CATEGORY)]
+        public void XMLSerializer_Deserialize_ClientSidePage_FlexibleLayoutSections_FromFallbackTypes()
+        {
+            var templateXml = @"<pnp:Provisioning xmlns:pnp=""http://schemas.dev.office.com/PnP/2022/09/ProvisioningSchema"">
+  <pnp:Templates>
+    <pnp:ProvisioningTemplate ID=""TEMPLATE-FLEXIBLE-LAYOUT"">
+      <pnp:ClientSidePages>
+        <pnp:ClientSidePage PageName=""FlexibleLayout.aspx"" Overwrite=""true"">
+          <pnp:Sections>
+            <pnp:Section Order=""1"" Type=""OneColumn"">
+              <pnp:Controls>
+                <pnp:CanvasControl WebPartType=""Custom"" CustomWebPartName=""Custom web part"" JsonControlData=""{&quot;flexibleLayoutPosition&quot;:{&quot;lg&quot;:{&quot;x&quot;:0,&quot;y&quot;:0,&quot;w&quot;:4,&quot;h&quot;:2}}}"" ControlId=""7a8004cb-8a1d-4fee-831d-2780ba29554c"" Order=""1"" Column=""1"" />
+              </pnp:Controls>
+            </pnp:Section>
+            <pnp:Section Order=""2"" Type=""OneColumnVerticalSection"">
+              <pnp:Controls>
+                <pnp:CanvasControl WebPartType=""Custom"" CustomWebPartName=""Custom web part"" JsonControlData=""{&quot;flexibleLayoutPosition&quot;:{&quot;lg&quot;:{&quot;x&quot;:0,&quot;y&quot;:0,&quot;w&quot;:4,&quot;h&quot;:2}}}"" ControlId=""311d802e-8e1d-4c43-989a-92a8b321e207"" Order=""1"" Column=""1"" />
+              </pnp:Controls>
+            </pnp:Section>
+          </pnp:Sections>
+        </pnp:ClientSidePage>
+      </pnp:ClientSidePages>
+    </pnp:ProvisioningTemplate>
+  </pnp:Templates>
+</pnp:Provisioning>";
+
+            var provider = new XMLFileSystemTemplateProvider(".", "");
+            var serializer = new TargetSerializer();
+            serializer.Initialize(provider);
+
+            using (var inputStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(templateXml)))
+            {
+                var template = serializer.ToProvisioningTemplate(inputStream);
+                var sections = template.ClientSidePages[0].Sections;
+
+                Assert.AreEqual(CanvasSectionType.FlexibleLayoutSection, sections[0].Type);
+                Assert.AreEqual(CanvasSectionType.FlexibleLayoutVerticalSection, sections[1].Type);
+            }
+        }
     }
 }

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -265,11 +265,11 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                                 sectionInstance.Type = CanvasSectionType.ThreeColumnVerticalSection;
                                 break;
                             case PnPCore.CanvasSectionTemplate.FlexibleLayoutSection:
-                                //XML Schema does not support FlexibleLayoutSection, so we need to fallback to OneColumn, during loading the page we have to restore from JsonControlData (sectionFactor=100)
+                                //XML Schema does not support FlexibleLayoutSection, so we need to fallback to OneColumn, during loading the page we have to restore from JsonControlData (flexibleLayoutPosition)
                                 sectionInstance.Type = CanvasSectionType.OneColumn;
                                 break;
                             case PnPCore.CanvasSectionTemplate.FlexibleLayoutVerticalSection:
-                                //XML Schema does not support FlexibleLayoutVerticalSection, so we need to fallback to OneColumnVerticalSection, during loading the page we have to restore from JsonControlData (sectionFactor=100)
+                                //XML Schema does not support FlexibleLayoutVerticalSection, so we need to fallback to OneColumnVerticalSection, during loading the page we have to restore from JsonControlData (flexibleLayoutPosition)
                                 sectionInstance.Type = CanvasSectionType.OneColumnVerticalSection;
                                 break;
                             default:

--- a/src/lib/PnP.Framework/Provisioning/Providers/Xml/Serializers/V201909/ClientSidePagesSerializer.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Xml/Serializers/V201909/ClientSidePagesSerializer.cs
@@ -78,7 +78,7 @@ namespace PnP.Framework.Provisioning.Providers.Xml.Serializers.V201909
                     {
                         foreach (var section in page.Sections.Where(s=>s.Type == CanvasSectionType.OneColumn || s.Type == CanvasSectionType.OneColumnVerticalSection))
                         {
-                            if (section.Controls != null && section.Controls.Any(c => !string.IsNullOrWhiteSpace(c.JsonControlData) && c.JsonControlData.Contains("\"sectionFactor\":100")))
+                            if (section.Controls != null && section.Controls.Any(c => !string.IsNullOrWhiteSpace(c.JsonControlData) && c.JsonControlData.Contains("\"flexibleLayoutPosition\"")))
                             {
                                 section.Type = section.Type == CanvasSectionType.OneColumn ? CanvasSectionType.FlexibleLayoutSection : CanvasSectionType.FlexibleLayoutVerticalSection;
                             }


### PR DESCRIPTION
## Summary

Closes #1206.

`OneColumnVerticalSection` was silently rewritten to `OneColumn` on `Save-PnPSiteTemplate` when the section contained `CallToAction` web parts.

**Root cause.** The flexible-layout detection heuristic in `ClientSidePagesSerializer` (V201909, shared by all schema versions) matched on `"sectionFactor":100`, which legitimately exists on legacy `CallToAction` controls. Affected sections were misclassified as `FlexibleLayout(Vertical)Section` on read; on write, the XSD fallback then degraded the type to `OneColumn`.

**Fix.** Switch the marker to `"flexibleLayoutPosition"`, which only appears on genuine flexible-layout web parts.

## Changes

- `src/lib/PnP.Framework/Provisioning/Providers/Xml/Serializers/V201909/ClientSidePagesSerializer.cs` — marker change (1 line).
- `src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs` — update stale `(sectionFactor=100)` comments to reference `flexibleLayoutPosition`, so future readers find the matching detection logic.
- `src/lib/PnP.Framework.Test/Framework/Providers/XMLSerializer202209Tests.cs` — two new tests.

## Test plan

- [x] `XMLSerializer_RoundTrip_ClientSidePage_OneColumnVerticalSection_WithCallToActionControls` — reproduces the issue exactly; passes with fix, fails without.
- [x] `XMLSerializer_Deserialize_ClientSidePage_FlexibleLayoutSections_FromFallbackTypes` — positive detection of `FlexibleLayoutSection` / `FlexibleLayoutVerticalSection` via the new marker.
- [x] All 372 tests across `XMLSerializer201909Tests` / `XMLSerializer202002Tests` / `XMLSerializer202103Tests` / `XMLSerializer202209Tests` pass.
- [x] End-to-end file-based round-trip via `XMLFileSystemTemplateProvider.GetTemplate` / `SaveAs` (the same APIs `Read-PnPSiteTemplate` / `Save-PnPSiteTemplate` invoke) confirms the exact `#1206` symptom — `Type` mangled from `OneColumnVerticalSection` to `OneColumn` — is gone across all four schema versions, and the bug reproduces in each schema without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)