### PR TITLE
Add support for new government cloud environments and update MSAL

### DIFF
--- a/src/lib/PnP.Framework.Test/TestCommon.cs
+++ b/src/lib/PnP.Framework.Test/TestCommon.cs
@@ -290,11 +290,7 @@ namespace PnP.Framework.Test
                 {
                     //clientContext = am.GetAppOnlyAuthenticatedContext(DevSiteUrl, Core.Utilities.TokenHelper.GetRealmFromTargetUrl(new Uri(DevSiteUrl)), AppId, AppSecret, acsHostUrl: "windows-ppe.net", globalEndPointPrefix: "login");
                     clientContext = am.GetACSAppOnlyContext(DevSiteUrl, AppId, AppSecret, AzureEnvironment.PPE);
-                }
-                else if (new Uri(DevSiteUrl).DnsSafeHost.Contains("sharepoint.de"))
-                {
-                    clientContext = am.GetACSAppOnlyContext(DevSiteUrl, AppId, AppSecret, AzureEnvironment.Germany);
-                }
+                }                
                 else
                 {
                     clientContext = am.GetACSAppOnlyContext(DevSiteUrl, AppId, AppSecret);

--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -51,7 +51,18 @@ namespace PnP.Framework
         /// 
         /// </summary>
         USGovernmentDoD = 6,
-
+        /// <summary>
+        /// 
+        /// </summary>
+        GovFr = 7,
+        /// <summary>
+        /// 
+        /// </summary>
+        GovDe = 8,
+        /// <summary>
+        /// 
+        /// </summary>
+        GovSg = 9,
         /// <summary>
         /// Custom cloud configuration, specify the endpoints manually
         /// </summary>
@@ -845,6 +856,9 @@ namespace PnP.Framework
                     Microsoft365Environment.USGovernment => AzureEnvironment.USGovernment,
                     Microsoft365Environment.USGovernmentHigh => AzureEnvironment.USGovernmentHigh,
                     Microsoft365Environment.USGovernmentDoD => AzureEnvironment.USGovernmentDoD,
+                    Microsoft365Environment.GovFr => AzureEnvironment.GovFr,
+                    Microsoft365Environment.GovDe => AzureEnvironment.GovDe,
+                    Microsoft365Environment.GovSg => AzureEnvironment.GovSg,
                     Microsoft365Environment.PreProduction => AzureEnvironment.PPE,
                     _ => AzureEnvironment.Production
                 };
@@ -1591,6 +1605,9 @@ namespace PnP.Framework
                 AzureEnvironment.USGovernment => "login",
                 AzureEnvironment.USGovernmentHigh => "login",
                 AzureEnvironment.USGovernmentDoD => "login",
+                AzureEnvironment.GovFr => "login",
+                AzureEnvironment.GovDe => "login",
+                AzureEnvironment.GovSg => "login",
                 AzureEnvironment.PPE => "login",
                 _ => "accounts"
             };
@@ -1685,6 +1702,9 @@ namespace PnP.Framework
                 AzureEnvironment.USGovernment => "https://login.microsoftonline.com",
                 AzureEnvironment.USGovernmentHigh => "https://login.microsoftonline.us",
                 AzureEnvironment.USGovernmentDoD => "https://login.microsoftonline.us",
+                AzureEnvironment.GovFr => "https://login.sovcloud-identity.fr",
+                AzureEnvironment.GovDe => "https://login.sovcloud-identity.de",
+                AzureEnvironment.GovSg => "https://login.sovcloud-identity.sg",
                 AzureEnvironment.PPE => "https://login.windows-ppe.net",
                 _ => "https://login.microsoftonline.com"
             };
@@ -1735,6 +1755,18 @@ namespace PnP.Framework
                     {
                         return "dod-graph.microsoft.us";
                     }
+                case AzureEnvironment.GovFr:
+                    {
+                        return "graph.svc.sovcloud.fr";
+                    }
+                case AzureEnvironment.GovDe:
+                    {
+                        return "graph.svc.sovcloud.de";
+                    }
+                case AzureEnvironment.GovSg:
+                    {
+                        return "graph.svc.sovcloud.sg";
+                    }
                 default:
                     {
                         return "graph.microsoft.com";
@@ -1776,6 +1808,9 @@ namespace PnP.Framework
                 AzureEnvironment.USGovernmentDoD => "us",
                 AzureEnvironment.Germany => "de",
                 AzureEnvironment.China => "cn",
+                AzureEnvironment.GovFr => "fr",
+                AzureEnvironment.GovDe => "de",
+                AzureEnvironment.GovSg => "sg",
                 _ => "com"
             };
         }
@@ -1987,6 +2022,21 @@ namespace PnP.Framework
                             builder = builder.WithAuthority(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMyOrg);
                             break;
                         }
+                    case AzureEnvironment.GovFr:
+                        {
+                            builder = builder.WithAuthority(AzureCloudInstance.GovFr, AadAuthorityAudience.AzureAdMyOrg);
+                            break;
+                        }
+                    case AzureEnvironment.GovDe:
+                        {
+                            builder = builder.WithAuthority(AzureCloudInstance.GovDe, AadAuthorityAudience.AzureAdMyOrg);
+                            break;
+                        }
+                    case AzureEnvironment.GovSg:
+                        {
+                            builder = builder.WithAuthority(AzureCloudInstance.GovSg, AadAuthorityAudience.AzureAdMyOrg);
+                            break;
+                        }
                 }
             }
             return builder;
@@ -2031,11 +2081,26 @@ namespace PnP.Framework
                             builder = builder.WithAuthority(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMyOrg);
                             break;
                         }
-                }
+                    case AzureEnvironment.GovFr:
+                        {
+                            builder = builder.WithAuthority(AzureCloudInstance.GovFr, AadAuthorityAudience.AzureAdMyOrg);
+                            break;
+                        }
+                    case AzureEnvironment.GovDe:
+                        {
+                            builder = builder.WithAuthority(AzureCloudInstance.GovDe, AadAuthorityAudience.AzureAdMyOrg);
+                            break;
+                        }
+                    case AzureEnvironment.GovSg:
+                        {
+                            builder = builder.WithAuthority(AzureCloudInstance.GovSg, AadAuthorityAudience.AzureAdMyOrg);
+                            break;
+                        }
+                }                
             }
             return builder;
         }
-
+        
         #endregion
     }
 }

--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -851,7 +851,6 @@ namespace PnP.Framework
                 this.azureEnvironment = pnPContext.Environment switch
                 {
                     Microsoft365Environment.Production => AzureEnvironment.Production,
-                    Microsoft365Environment.Germany => AzureEnvironment.Germany,
                     Microsoft365Environment.China => AzureEnvironment.China,
                     Microsoft365Environment.USGovernment => AzureEnvironment.USGovernment,
                     Microsoft365Environment.USGovernmentHigh => AzureEnvironment.USGovernmentHigh,
@@ -1580,11 +1579,10 @@ namespace PnP.Framework
             return (environment) switch
             {
                 AzureEnvironment.Production => "accesscontrol.windows.net",
-                AzureEnvironment.Germany => "microsoftonline.de",
                 AzureEnvironment.China => "accesscontrol.chinacloudapi.cn",
                 AzureEnvironment.USGovernment => "accesscontrol.windows.net",
                 AzureEnvironment.USGovernmentHigh => "microsoftonline.us",
-                AzureEnvironment.USGovernmentDoD => "microsoftonline.us",
+                AzureEnvironment.USGovernmentDoD => "microsoftonline.us",                
                 AzureEnvironment.PPE => "windows-ppe.net",
                 _ => "accesscontrol.windows.net"
             };
@@ -1600,7 +1598,6 @@ namespace PnP.Framework
             return (environment) switch
             {
                 AzureEnvironment.Production => "accounts",
-                AzureEnvironment.Germany => "login",
                 AzureEnvironment.China => "accounts",
                 AzureEnvironment.USGovernment => "login",
                 AzureEnvironment.USGovernmentHigh => "login",
@@ -1697,7 +1694,6 @@ namespace PnP.Framework
             return (environment) switch
             {
                 AzureEnvironment.Production => "https://login.microsoftonline.com",
-                AzureEnvironment.Germany => "https://login.microsoftonline.de",
                 AzureEnvironment.China => "https://login.chinacloudapi.cn",
                 AzureEnvironment.USGovernment => "https://login.microsoftonline.com",
                 AzureEnvironment.USGovernmentHigh => "https://login.microsoftonline.us",
@@ -1738,11 +1734,7 @@ namespace PnP.Framework
                 case AzureEnvironment.USGovernment:
                     {
                         return "graph.microsoft.com";
-                    }
-                case AzureEnvironment.Germany:
-                    {
-                        return "graph.microsoft.de";
-                    }
+                    }                
                 case AzureEnvironment.China:
                     {
                         return "microsoftgraph.chinacloudapi.cn";
@@ -1806,7 +1798,6 @@ namespace PnP.Framework
                 AzureEnvironment.USGovernment => "com",
                 AzureEnvironment.USGovernmentHigh => "us",
                 AzureEnvironment.USGovernmentDoD => "us",
-                AzureEnvironment.Germany => "de",
                 AzureEnvironment.China => "cn",
                 AzureEnvironment.GovFr => "fr",
                 AzureEnvironment.GovDe => "de",
@@ -2011,12 +2002,7 @@ namespace PnP.Framework
                         {
                             builder = builder.WithAuthority(AzureCloudInstance.AzureUsGovernment, AadAuthorityAudience.AzureAdMyOrg);
                             break;
-                        }
-                    case AzureEnvironment.Germany:
-                        {
-                            builder = builder.WithAuthority(AzureCloudInstance.AzureGermany, AadAuthorityAudience.AzureAdMyOrg);
-                            break;
-                        }
+                        }                    
                     case AzureEnvironment.China:
                         {
                             builder = builder.WithAuthority(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMyOrg);
@@ -2071,11 +2057,6 @@ namespace PnP.Framework
                             builder = builder.WithAuthority(AzureCloudInstance.AzureUsGovernment, AadAuthorityAudience.AzureAdMyOrg);
                             break;
                         }
-                    case AzureEnvironment.Germany:
-                        {
-                            builder = builder.WithAuthority(AzureCloudInstance.AzureGermany, AadAuthorityAudience.AzureAdMyOrg);
-                            break;
-                        }
                     case AzureEnvironment.China:
                         {
                             builder = builder.WithAuthority(AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMyOrg);
@@ -2096,11 +2077,11 @@ namespace PnP.Framework
                             builder = builder.WithAuthority(AzureCloudInstance.GovSg, AadAuthorityAudience.AzureAdMyOrg);
                             break;
                         }
-                }                
+                }
             }
             return builder;
         }
-        
+
         #endregion
     }
 }

--- a/src/lib/PnP.Framework/Extensions/InternalClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/InternalClientContextExtensions.cs
@@ -47,8 +47,10 @@ namespace Microsoft.SharePoint.Client
                     {
                         "com" => AzureEnvironment.Production,
                         "us" => AzureEnvironment.USGovernment,
-                        "de" => AzureEnvironment.Germany,
+                        "de" => AzureEnvironment.GovDe,
                         "cn" => AzureEnvironment.China,
+                        "fr" => AzureEnvironment.GovFr,
+                        "sg" => AzureEnvironment.GovSg,
                         _ => AzureEnvironment.Production,
                     };
                 }

--- a/src/lib/PnP.Framework/PnP.Framework.csproj
+++ b/src/lib/PnP.Framework/PnP.Framework.csproj
@@ -251,9 +251,9 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.73.0" />
-		<PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.73.0" />
-		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.73.0" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
+		<PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.85.2" />
+		<PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.85.2" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="AngleSharp" Version="0.17.0" />
 		<PackageReference Include="AngleSharp.Css" Version="0.17.0" />


### PR DESCRIPTION
Added support for DelosCloud, BleuCloud, and GovSGCloud Azure environments in AuthenticationManager, including new enum values and endpoint logic. Updated GetBuilderWithAuthority to handle these environments. Upgraded Microsoft.Identity.Client packages to version 4.85.2.

Depends on : [pnpcore/1727](https://github.com/pnp/pnpcore/pull/1727)