### PR TITLE
Fix broken add-owner/add-member Graph calls in Groups utilities

### DIFF
--- a/src/lib/PnP.Framework/Graph/GroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/GroupsUtility.cs
@@ -121,8 +121,9 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // And if any, add it to the collection of group's members
-                        var memberUrl = $"{groupRequestUrl}/members/{user.Id}/ref";
-                        HttpHelper.MakePostRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
+                        var memberUrl = $"{groupRequestUrl}/members/$ref";
+                        object content = new JObject { ["@odata.id"] = $"{userRequestUrl}/{user.Id}" };
+                        HttpHelper.MakePostRequest(memberUrl, content, HttpHelper.JsonContentType, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (Exception ex) when (ex.Message.Contains("Request_BadRequest") &&
                             ex.Message.Contains("added object references already exist"))
@@ -150,7 +151,7 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // If it is not in the list of current members, just remove it
-                        var memberUrl = $"{groupRequestUrl}/members/{member.Id}/ref";
+                        var memberUrl = $"{groupRequestUrl}/members/{member.Id}/$ref";
                         HttpHelper.MakeDeleteRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (HttpResponseException ex) when (ex.StatusCode == 400)
@@ -187,8 +188,9 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // And if any, add it to the collection of group's owners
-                        var memberUrl = $"{groupRequestUrl}/owners/{user.Id}/ref";
-                        HttpHelper.MakePostRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
+                        var memberUrl = $"{groupRequestUrl}/owners/$ref";
+                        object content = new JObject { ["@odata.id"] = $"{userRequestUrl}/{user.Id}" };
+                        HttpHelper.MakePostRequest(memberUrl, content, HttpHelper.JsonContentType, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (Exception ex) when (ex.Message.Contains("Request_BadRequest") &&
                             ex.Message.Contains("added object references already exist"))
@@ -216,7 +218,7 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // If it is not in the list of current owners, just remove it
-                        var memberUrl = $"{groupRequestUrl}/owners/{owner.Id}/ref";
+                        var memberUrl = $"{groupRequestUrl}/owners/{owner.Id}/$ref";
                         HttpHelper.MakeDeleteRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (HttpResponseException ex) when (ex.StatusCode == 400)

--- a/src/lib/PnP.Framework/Graph/GroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/GroupsUtility.cs
@@ -643,7 +643,7 @@ namespace PnP.Framework.Graph
                         try
                         {
                             // If it is not in the list of current members, just remove it
-                            var deleteGroupMemberUrl = $"{groupRequestUrl}/members/{userId}/ref";
+                            var deleteGroupMemberUrl = $"{groupRequestUrl}/members/{userId}/$ref";
                             HttpHelper.MakeDeleteRequest(deleteGroupMemberUrl, accessToken, retryCount: retryCount, delay: delay);
                         }
                         catch (HttpResponseException ex) when (ex.StatusCode == 400)
@@ -696,7 +696,7 @@ namespace PnP.Framework.Graph
                         try
                         {
                             // If it is not in the list of current owners, just remove it
-                            var deleteGroupMemberUrl = $"{groupRequestUrl}/owners/{userId}/ref";
+                            var deleteGroupMemberUrl = $"{groupRequestUrl}/owners/{userId}/$ref";
                             HttpHelper.MakeDeleteRequest(deleteGroupMemberUrl, accessToken, retryCount: retryCount, delay: delay);
                         }
                         catch (HttpResponseException ex) when (ex.StatusCode == 400)

--- a/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
@@ -1162,7 +1162,7 @@ namespace PnP.Framework.Graph
                         try
                         {
                             // If it is not in the list of current members, just remove it
-                            var deleteGroupMemberUrl = $"{groupRequestUrl}/members/{userId}/ref";
+                            var deleteGroupMemberUrl = $"{groupRequestUrl}/members/{userId}/$ref";
                             HttpHelper.MakeDeleteRequest(deleteGroupMemberUrl, accessToken, retryCount: retryCount, delay: delay);
                         }
                         catch (HttpResponseException ex) when (ex.StatusCode == 400)
@@ -1215,7 +1215,7 @@ namespace PnP.Framework.Graph
                         try
                         {
                             // If it is not in the list of current owners, just remove it
-                            var deleteGroupMemberUrl = $"{groupRequestUrl}/owners/{userId}/ref";
+                            var deleteGroupMemberUrl = $"{groupRequestUrl}/owners/{userId}/$ref";
                             HttpHelper.MakeDeleteRequest(deleteGroupMemberUrl, accessToken, retryCount: retryCount, delay: delay);
                         }
                         catch (HttpResponseException ex) when (ex.StatusCode == 400)

--- a/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UnifiedGroupsUtility.cs
@@ -324,8 +324,9 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // And if any, add it to the collection of group's members
-                        var memberUrl = $"{groupRequestUrl}/members/{user.Id}/ref";
-                        HttpHelper.MakePostRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
+                        var memberUrl = $"{groupRequestUrl}/members/$ref";
+                        object content = new JObject { ["@odata.id"] = $"{userRequestUrl}/{user.Id}" };
+                        HttpHelper.MakePostRequest(memberUrl, content, HttpHelper.JsonContentType, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (Exception ex) when (ex.Message.Contains("Request_BadRequest") &&
                             ex.Message.Contains("added object references already exist"))
@@ -353,7 +354,7 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // If it is not in the list of current members, just remove it
-                        var memberUrl = $"{groupRequestUrl}/members/{member.Id}/ref";
+                        var memberUrl = $"{groupRequestUrl}/members/{member.Id}/$ref";
                         HttpHelper.MakeDeleteRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (HttpResponseException ex) when (ex.StatusCode == 400)
@@ -390,8 +391,9 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // And if any, add it to the collection of group's owners
-                        var memberUrl = $"{groupRequestUrl}/owners/{user.Id}/ref";
-                        HttpHelper.MakePostRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
+                        var memberUrl = $"{groupRequestUrl}/owners/$ref";
+                        object content = new JObject { ["@odata.id"] = $"{userRequestUrl}/{user.Id}" };
+                        HttpHelper.MakePostRequest(memberUrl, content, HttpHelper.JsonContentType, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (Exception ex) when (ex.Message.Contains("Request_BadRequest") &&
                             ex.Message.Contains("added object references already exist"))
@@ -419,7 +421,7 @@ namespace PnP.Framework.Graph
                     try
                     {
                         // If it is not in the list of current owners, just remove it
-                        var memberUrl = $"{groupRequestUrl}/owners/{owner.Id}/ref";
+                        var memberUrl = $"{groupRequestUrl}/owners/{owner.Id}/$ref";
                         HttpHelper.MakeDeleteRequest(memberUrl, accessToken, retryCount: retryCount, delay: delay);
                     }
                     catch (HttpResponseException ex) when (ex.StatusCode == 400)


### PR DESCRIPTION
UpdateOwners/UpdateMembers in both GroupsUtility and UnifiedGroupsUtility passed accessToken positionally into MakePostRequest parameter 2, which is the request body (object content) - not the access token. This sent the token as the POST body with no auth header and no @odata.id reference payload, so adding owners/members was non-functional. The bug came from the Graph SDK -> HttpHelper migration (2435d060, cf619edd).

Align all four add/remove paths with the working ObjectTeams pattern:
- POST .../{owners|members}/$ref with an {"@odata.id": ".../users/{id}"} body, application/json content type, and accessToken in the correct slot
- Correct the DELETE reference URLs from /ref to /$ref