### PR TITLE
fix for issue 1230.

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -2718,10 +2718,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                 web.Context.ExecuteQueryRetry();
                 foreach (var fieldLink in ct.FieldLinks)
                 {
-                    if (!fieldLink.Hidden)
-                    {
-                        contentTypeFields.Add(new FieldRef() { Id = fieldLink.Id });
-                    }
+                    contentTypeFields.Add(new FieldRef() { Id = fieldLink.Id }); 
                 }
                 count++;
             }


### PR DESCRIPTION
# Hotfix for issue #1230 

## Problem

Currently I find an issue in list provisioning:

If the list has custom content type which contains hidden site column , the exported template won't have this field ref . See detail in #1230 

It will become a problem if its site level content type doesn't have this field (only list level content type has this field ), then this field won't be provisioned.

## My hotfix

I checked the related code and found that this module is quite old and stable (It doesn't have too much change compared with its initial version)

It seems that the first author want to exclude the system fields (system fields won't be added into content type)  in the list provisioning.

Now `contentTypeFields` will add all the field link in the list content types no matter whether it is hidden or not, to avoid this issue.




