### PR TITLE
Fix ListUserDelta throwing on a null delta token and never returning one

### DIFF
--- a/src/lib/PnP.Framework/Graph/UsersUtility.cs
+++ b/src/lib/PnP.Framework/Graph/UsersUtility.cs
@@ -191,16 +191,19 @@ namespace PnP.Framework.Graph
 
             Dictionary<string, string> additionalHeaders = null;
 
-            var requestUrl = $"{GraphHttpClient.GetGraphEndPointUrl(azureEnvironment)}users";
+            // Change tracking lives on the delta function. A plain users query never returns
+            // an @odata.deltaLink, so without /delta there is no token to hand back to the caller.
+            var requestUrl = $"{GraphHttpClient.GetGraphEndPointUrl(azureEnvironment)}users/delta";
             var queryStringParams = new List<string>
             {
                 $"$top={(!endIndex.HasValue ? 999 : endIndex.Value >= 999 ? 999 : endIndex.Value)}"
             };
 
-            // Add $skiptoken only if deltaToken is not null or empty
+            // Add $deltatoken only if deltaToken is not null or empty. The token was extracted
+            // from a $deltatoken URL in a previous round, so that is the parameter it belongs in.
             if (!string.IsNullOrEmpty(deltaToken))
             {
-                queryStringParams.Add($"$skiptoken={deltaToken}");
+                queryStringParams.Add($"$deltatoken={deltaToken}");
             }
 
             if (propertiesToSelect.Count > 0)
@@ -255,9 +258,10 @@ namespace PnP.Framework.Graph
                     usersDelta.NextLink = jsonNode["@odata.nextLink"]?.ToString();
                     requestUrl = (endIndex.HasValue && endIndex.Value < currentIndex) ? null : usersDelta.NextLink;
 
-                    var deltaLink = jsonNode["@odata.deltalink"]?.ToString();
+                    // Graph spells this @odata.deltaLink and JsonNode lookups are case sensitive.
+                    var deltaLink = jsonNode["@odata.deltaLink"]?.ToString() ?? jsonNode["@odata.deltalink"]?.ToString();
 
-                    if (string.IsNullOrWhiteSpace(deltaLink))
+                    if (!string.IsNullOrWhiteSpace(deltaLink))
                     {
                         // Use a regular expression to fetch just the deltatoken part from the deltalink. The base of the URL will thereby be cut off. This is the only part we need to use it in a subsequent run.
                         var deltaLinkMatch = System.Text.RegularExpressions.Regex.Match(deltaLink, @"(?<=\$deltatoken=)(.*?)(?=$|&)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

Fixes #1156

## What is in this Pull Request

`UsersUtility.ListUserDelta` throws `ArgumentNullException: Value cannot be null. (Parameter 'input')` on a first run, which is the run where no delta token exists yet. This is what `Get-PnPAzureADUser -Delta` does in PnP PowerShell, so that cmdlet cannot complete its initial call.

Three defects, all dating from the removal of the Graph SDK in 5355b6f9, combine to produce it:

1. **Wrong endpoint.** The method queried `users` rather than `users/delta`. Change tracking lives on the delta function, so a plain user query never returns an `@odata.deltaLink` and there is never a token to hand back to the caller.

2. **Wrong casing on the delta link.** The response was read as `jsonNode["@odata.deltalink"]`, but Graph emits `@odata.deltaLink` and `JsonNode` lookups are case sensitive. Even on the delta endpoint this would always have come back null. Both spellings are now accepted.

3. **Inverted null guard.** The extraction ran when the link was *missing*:

   ```csharp
   if (string.IsNullOrWhiteSpace(deltaLink))
   {
       var deltaLinkMatch = Regex.Match(deltaLink, @"(?<=\$deltatoken=)(.*?)(?=$|&)", ...);
   ```

   `Regex.Match` rejects a null `input`, which is the exception in the issue title. Combined with 1 and 2 the link was always missing, so the throw was unconditional.

A supplied delta token is also now sent back as `$deltatoken` rather than `$skiptoken`. The token is extracted from a `$deltatoken=` URL, so that is the parameter it belongs in; `$skiptoken` is for paging within a single round.

### Verification

Called `ListUserDelta` directly, app-only with a certificate against a test tenant, before and after the change. Run 1 passes a null delta token, run 2 passes back whatever run 1 returned.

Before, run 1 throws at `UsersUtility.cs:263`:

![Before the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1156/listuserdelta-prefix-evidence.png)

After, run 1 returns the full set of users plus a delta token, and run 2 uses that token to return only what changed since:

![After the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1156/listuserdelta-postfix-evidence.png)

Builds clean for `netstandard2.0`, `net8.0` and `net9.0`.

### Note on filter and orderby

Graph supports only `$filter=id eq '{value}'` on `users/delta`, and does not support `$orderby` there at all, so callers passing an arbitrary `filter` or `orderby` to this method will now get a `400` from Graph instead of a non-delta result with no token. That matches how the method behaved before the Graph SDK was removed, since the old implementation also applied `.Filter()` and `.OrderBy()` to a `Users.Delta()` request. Happy to reshape that separately if you would rather those arguments were rejected client side with a clearer message.

No CHANGELOG entry included. Glad to add one if you want it for this repo.
