### PR TITLE
Make the provisioning field XML cache thread safe

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/FieldAndListProvisioningStepHelper.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Xml.Linq;
 using Field = PnP.Framework.Provisioning.Model.Field;
 
@@ -7,15 +7,13 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 {
     public static class FieldAndListProvisioningStepHelper
     {
-        static readonly Dictionary<Field, XElement> _fieldXmlDictionary = new Dictionary<Field, XElement>();
+        // Process wide cache, so it is shared by every provisioning run in the process.
+        // A plain Dictionary corrupts itself when two runs provision fields at the same time.
+        static readonly ConcurrentDictionary<Field, XElement> _fieldXmlDictionary = new ConcurrentDictionary<Field, XElement>();
+
         internal static Step GetFieldProvisioningStep(this Field templateField, TokenParser parser)
         {
-            XElement schemaElement;
-            if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
-            {
-                schemaElement = XElement.Parse(parser.ParseXmlString(templateField.SchemaXml));
-                _fieldXmlDictionary[templateField] = schemaElement;
-            }
+            var schemaElement = GetCachedSchemaXml(templateField, parser);
             var type = (string)schemaElement.Attribute("Type");
             if (type != "Lookup" && type != "LookupMulti" && type != "Calculated")
             {
@@ -26,25 +24,21 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
 
         internal static Guid GetFieldId(this Field templateField, TokenParser parser)
         {
-            XElement schemaElement;
-            if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
-            {
-                schemaElement = XElement.Parse(parser.ParseXmlString(templateField.SchemaXml));
-                _fieldXmlDictionary[templateField] = schemaElement;
-            }
+            var schemaElement = GetCachedSchemaXml(templateField, parser);
             var id = (Guid)schemaElement.Attribute("ID");
             return id;
         }
 
         internal static XElement GetSchemaXml(this Field templateField, TokenParser parser, params string[] tokensToSkip)
         {
-            XElement schemaElement;
-            if (!_fieldXmlDictionary.TryGetValue(templateField, out schemaElement))
-            {
-                schemaElement = XElement.Parse(parser.ParseXmlString(templateField.SchemaXml, tokensToSkip));
-                _fieldXmlDictionary[templateField] = schemaElement;
-            }
-            return schemaElement;
+            return GetCachedSchemaXml(templateField, parser, tokensToSkip);
+        }
+
+        private static XElement GetCachedSchemaXml(Field templateField, TokenParser parser, params string[] tokensToSkip)
+        {
+            return _fieldXmlDictionary.GetOrAdd(
+                templateField,
+                field => XElement.Parse(parser.ParseXmlString(field.SchemaXml, tokensToSkip)));
         }
 
         public enum Step


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

Fixes #1243

## What is in this Pull Request

`FieldAndListProvisioningStepHelper` cached parsed field schema XML in a process wide static `Dictionary<Field, XElement>`:

```csharp
static readonly Dictionary<Field, XElement> _fieldXmlDictionary = new Dictionary<Field, XElement>();
```

The three helpers that read it, `GetFieldProvisioningStep`, `GetFieldId` and `GetSchemaXml`, each did an unsynchronised check-then-insert on that dictionary. Because the cache is static, provisioning runs that are independent from the caller's point of view still share it, so two `ApplyProvisioningTemplate` calls running at the same time in one process write to the same `Dictionary` concurrently and corrupt it. That surfaces as

```text
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access.
```

thrown out of `ObjectField.ProvisionObjects`. The keys do not need to collide for this to happen, and a corrupted `Dictionary` can also spin inside a lookup, so a long running host can keep failing until the process is recycled.

This replaces the cache with a `ConcurrentDictionary` and routes all three helpers through one `GetOrAdd` based `GetCachedSchemaXml`, which also removes the three copies of the same check-then-insert block. Caching behaviour, the keys used and every method signature stay the same.

### Verification

A small console harness drives the real code path: 8 concurrent runs, each with its own template fields, 400 fields per run, classified through `GetFieldProvisioningStep` exactly as `ObjectField` does. Nothing is shared by the caller, so the only shared state is the framework's static cache.

Before, every run fails with the exception from the issue:

![Before the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1243/fieldcache-before-fix.png)

After, all 3200 fields are classified without error, and a follow up check confirms the cache still serves repeated fields and still routes `Lookup`/`Calculated` fields to `Step.LookupFields`:

![After the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1243/fieldcache-after-fix.png)

Builds clean for `netstandard2.0`, `net8.0` and `net9.0`.

### Note

I could not add a regression test to `PnP.Framework.Test`: it targets `net10.0` only and I have no .NET 10 SDK on this machine, so anything I wrote there would go in unverified. The harness above needs reflection anyway, since these helpers are `internal` and `TokenParser`'s token list constructor is private. Happy to add a test in the shape you prefer if you would like one.

Two related things I deliberately left alone, since they are separate from the crash in the issue:

- The cache is never trimmed, so it grows for the lifetime of the process.
- `Field.GetHashCode()` parses the schema XML on every call, so each cache lookup already costs one `XElement.Parse`, which is most of what the cache is meant to avoid.

No CHANGELOG entry included.
