### PR TITLE
Stop forcing a legacy TLS preference on net10.0

### DIFF
--- a/src/lib/PnP.Framework.Test/AuthenticationManagerTests.cs
+++ b/src/lib/PnP.Framework.Test/AuthenticationManagerTests.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+
+namespace PnP.Framework.Test
+{
+    [TestClass]
+    public class AuthenticationManagerTests
+    {
+        /// <summary>
+        /// PnP Framework only forces a process wide TLS preference on the legacy targets. The
+        /// guards that do so are compiled out from net9.0 onwards, and this test project runs on
+        /// the newest supported target framework, so the preference has to be left alone here.
+        /// A guard written for one single target framework silently starts applying again on the
+        /// next one, which is what happened to net10.0 in issue #1218.
+        /// </summary>
+        [TestMethod]
+        public void ConstructorDoesNotChangeProcessWideTlsPreference()
+        {
+#pragma warning disable SYSLIB0014 // ServicePointManager is obsolete, it is read here to assert it stays untouched
+            SecurityProtocolType before = ServicePointManager.SecurityProtocol;
+
+            using (new AuthenticationManager())
+            {
+            }
+
+            Assert.AreEqual(before, ServicePointManager.SecurityProtocol);
+#pragma warning restore SYSLIB0014
+        }
+    }
+}

--- a/src/lib/PnP.Framework/AuthenticationManager.cs
+++ b/src/lib/PnP.Framework/AuthenticationManager.cs
@@ -354,7 +354,7 @@ namespace PnP.Framework
         /// </summary>
         public AuthenticationManager()
         {
-#if !NET9_0
+#if !NET9_0_OR_GREATER
             // Set the TLS preference. Needed on some server os's to work when Office 365 removes support for TLS 1.0
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 #endif

--- a/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
+++ b/src/lib/PnP.Framework/Extensions/ClientContextExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.SharePoint.Client
 
             await new SynchronizationContextRemover();
 
-#if !NET9_0
+#if !NET9_0_OR_GREATER
             // Set the TLS preference. Needed on some server os's to work when Office 365 removes support for TLS 1.0
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 #endif

--- a/src/lib/PnP.Framework/Http/PnPHttpClient.cs
+++ b/src/lib/PnP.Framework/Http/PnPHttpClient.cs
@@ -132,7 +132,7 @@ namespace PnP.Framework.Http
                 semaphoreSlimFactory.Wait();
 
                 // Use TLS 1.2 as default connection
-#if !NET9_0
+#if !NET9_0_OR_GREATER
                 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 #endif
 

--- a/src/lib/PnP.Framework/Utilities/PnPHttpProvider.cs
+++ b/src/lib/PnP.Framework/Utilities/PnPHttpProvider.cs
@@ -48,7 +48,7 @@ namespace PnP.Framework.Utilities
         {
             this.userAgent = userAgent;
 
-#if !NET9_0
+#if !NET9_0_OR_GREATER
             // Use TLS 1.2 as default connection	
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 #endif


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

Fixes #1218

## What is in this Pull Request

To answer the question in the issue: yes, this is a real problem, and it is not limited to `ExecuteQueryImplementation`.

Four places assign the process wide TLS preference behind the same guard:

```csharp
#if !NET9_0
    // Set the TLS preference. Needed on some server os's to work when Office 365 removes support for TLS 1.0
    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
#endif
```

- `AuthenticationManager..ctor`
- `ClientContextExtensions.ExecuteQueryImplementation`
- `PnPHttpClient.BuildServiceFactory`
- `PnPHttpProvider..ctor`

`NET9_0` matches exactly one target framework. When the guard was added in eec5fb22, net9.0 was the newest target, so it read as "not on the modern runtime". Adding `net10.0` to `TargetFrameworks` silently undid that: the net10.0 build compiles the legacy assignment back in, while net9.0 does not.

The effect on an application running on .NET 10 is that merely touching PnP Framework rewrites the TLS policy for the whole process to `Tls | Tls11 | Tls12`, which puts TLS 1.0 and 1.1 back on the table and takes TLS 1.3 off it. `ServicePointManager` is also obsolete on that runtime.

`#if !NET9_0_OR_GREATER` keeps the assignment exactly where it is meant to be, on `netstandard2.0` and `net8.0`, and keeps it out of every current and future modern target, so the next TFM bump does not reintroduce this.

### Verification

The same program, built against the net8.0, net9.0 and net10.0 build of PnP.Framework, calling `new AuthenticationManager()` and reporting `ServicePointManager.SecurityProtocol` before and after.

Before, net8.0 and net9.0 behave as intended and net10.0 does not:

![Before the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1218/net10-tls-before-fix.png)

After, net10.0 matches net9.0 and net8.0 keeps the legacy assignment:

![After the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1218/net10-tls-after-fix.png)

Builds clean for `netstandard2.0`, `net8.0`, `net9.0` and `net10.0`.

### Regression test

`AuthenticationManagerTests.ConstructorDoesNotChangeProcessWideTlsPreference` asserts that constructing an `AuthenticationManager` leaves `ServicePointManager.SecurityProtocol` alone. The test project runs on the newest supported target framework, so this fails whenever a guard of this shape stops covering the newest target, which is exactly the mistake being fixed here. Verified both ways with `dotnet test --filter FullyQualifiedName~AuthenticationManagerTests`: it fails on `dev` and passes with this change.

No CHANGELOG entry included.
