### PR TITLE
Add the missing Office 365 geography codes

### DIFF
--- a/src/lib/PnP.Framework.Test/Enums/Office365GeographyTests.cs
+++ b/src/lib/PnP.Framework.Test/Enums/Office365GeographyTests.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PnP.Framework.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PnP.Framework.Test.Enums
+{
+    [TestClass]
+    public class Office365GeographyTests
+    {
+        /// <summary>
+        /// The PreferredDataLocation values from the table this enum documents itself against,
+        /// https://learn.microsoft.com/microsoft-365/enterprise/multi-geo-add-group-with-pdl#geo-location-codes
+        /// </summary>
+        private static readonly string[] DocumentedGeoLocationCodes =
+        {
+            "APC", "AUS", "AUT", "BRA", "CAN", "CHL", "DNK", "EUR", "FRA", "DEU",
+            "IND", "IDN", "ISR", "ITA", "JPN", "KOR", "MYS", "MEX", "NZL", "NOR",
+            "POL", "QAT", "ZAF", "ESP", "SWE", "CHE", "TWN", "ARE", "GBR", "NAM",
+        };
+
+        /// <summary>
+        /// Callers pass these codes straight through as PreferredDataLocation and the value is
+        /// sent on with ToString(), so every documented code has to exist as a member and has to
+        /// keep its own name.
+        /// </summary>
+        [TestMethod]
+        public void EveryDocumentedGeoLocationCodeIsSupported()
+        {
+            List<string> missing = DocumentedGeoLocationCodes
+                .Where(code => !Enum.TryParse(code, out Office365Geography parsed) || parsed.ToString() != code)
+                .ToList();
+
+            Assert.AreEqual(0, missing.Count, $"Not usable as PreferredDataLocation: {string.Join(", ", missing)}");
+        }
+    }
+}

--- a/src/lib/PnP.Framework/Enums/Office365Geography.cs
+++ b/src/lib/PnP.Framework/Enums/Office365Geography.cs
@@ -94,5 +94,65 @@
         /// Sweden
         /// </summary>
         SWE,
+
+        /// <summary>
+        /// Austria
+        /// </summary>
+        AUT,
+
+        /// <summary>
+        /// Chile
+        /// </summary>
+        CHL,
+
+        /// <summary>
+        /// Denmark
+        /// </summary>
+        DNK,
+
+        /// <summary>
+        /// Spain
+        /// </summary>
+        ESP,
+
+        /// <summary>
+        /// Indonesia
+        /// </summary>
+        IDN,
+
+        /// <summary>
+        /// Israel
+        /// </summary>
+        ISR,
+
+        /// <summary>
+        /// Italy
+        /// </summary>
+        ITA,
+
+        /// <summary>
+        /// Mexico
+        /// </summary>
+        MEX,
+
+        /// <summary>
+        /// Malaysia
+        /// </summary>
+        MYS,
+
+        /// <summary>
+        /// New Zealand
+        /// </summary>
+        NZL,
+
+        /// <summary>
+        /// Poland
+        /// </summary>
+        POL,
+
+        /// <summary>
+        /// Taiwan
+        /// </summary>
+        TWN,
     }
 }


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

Fixes #1170

## What is in this Pull Request

`Office365Geography` is the type behind `PreferredDataLocation` on `SiteCollectionCreationInformation`, `CommunicationSiteCollectionCreationInformation` and the `UnifiedGroupsUtility` group creation overloads. It listed 18 of the 30 codes in the geo location table its own summary links to, so a tenant in one of the other twelve could not be addressed at all:

```text
Cannot convert value "NZL" to type "PnP.Framework.Enums.Office365Geography".
Error: "Unable to match the identifier name NZL to a valid enumerator name."
```

Missing: `AUT` Austria, `CHL` Chile, `DNK` Denmark, `ESP` Spain, `IDN` Indonesia, `ISR` Israel, `ITA` Italy, `MEX` Mexico, `MYS` Malaysia, `NZL` New Zealand, `POL` Poland, `TWN` Taiwan.

The value reaches the service through `ToString()` in `SiteCollection.cs` and `UnifiedGroupsUtility.cs`, so the member name is the code itself and nothing else has to change. The new members are appended rather than sorted in, so every existing member keeps its numeric value.

Source for the list is the table this enum already points at, [geo location codes](https://learn.microsoft.com/microsoft-365/enterprise/multi-geo-add-group-with-pdl#geo-location-codes).

### Verification

Binding each documented code to `Office365Geography` and checking it round trips through `ToString()`, plus the `PreferredDataLocation` assignment from the issue.

Before, twelve codes cannot be bound and New Zealand throws:

![Before the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1170/geography-before-fix.png)

After, all thirty bind and `PreferredDataLocation = NZL` is accepted:

![After the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1170/geography-after-fix.png)

Builds clean for `netstandard2.0`, `net8.0`, `net9.0` and `net10.0`.

### Regression test

`Office365GeographyTests.EveryDocumentedGeoLocationCodeIsSupported` walks the documented code list and reports the ones that are not usable, so the next geography Microsoft adds shows up as a failing test with the codes named rather than as a bind error at runtime. Verified both ways with `dotnet test --filter FullyQualifiedName~Office365GeographyTests`: on `dev` it fails listing the twelve, with this change it passes.

No CHANGELOG entry included.
