### PR TITLE
Keep ListInstance DataSource across a template round trip

### DIFF
--- a/src/lib/PnP.Framework.Test/Framework/Providers/ListInstanceDataSourceTests.cs
+++ b/src/lib/PnP.Framework.Test/Framework/Providers/ListInstanceDataSourceTests.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PnP.Framework.Provisioning.Model;
+using PnP.Framework.Provisioning.Providers.Xml;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace PnP.Framework.Test.Framework.Providers
+{
+    [TestClass]
+    public class ListInstanceDataSourceTests
+    {
+        /// <summary>
+        /// One external list carrying BCS settings and one library carrying default column values.
+        /// Both settings are StringDictionaryItem arrays on the same list type, which is what the
+        /// serializers used to confuse.
+        /// </summary>
+        private const string Template = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<pnp:Provisioning xmlns:pnp=""http://schemas.dev.office.com/PnP/2022/09/ProvisioningSchema"">
+  <pnp:Templates ID=""CONTAINER"">
+    <pnp:ProvisioningTemplate ID=""SAMPLE"" Version=""1"">
+      <pnp:Lists>
+        <pnp:ListInstance Title=""Customers"" Url=""Lists/Customers"" TemplateType=""600"">
+          <pnp:DataSource>
+            <pnp:DataSourceItem Key=""LobSystemInstance"" Value=""ODS"" />
+            <pnp:DataSourceItem Key=""EntityNamespace"" Value=""https://sample.contoso.com/ODS"" />
+            <pnp:DataSourceItem Key=""Entity"" Value=""ODS.Customer"" />
+            <pnp:DataSourceItem Key=""SpecificFinder"" Value=""CustomerRead Item"" />
+          </pnp:DataSource>
+        </pnp:ListInstance>
+        <pnp:ListInstance Title=""Documents"" Url=""Shared Documents"" TemplateType=""101"">
+          <pnp:DefaultColumnValues>
+            <pnp:DefaultColumnValue Key=""Field1"" Value=""Custom Value 1"" />
+            <pnp:DefaultColumnValue Key=""Field2"" Value=""Custom Value 2"" />
+          </pnp:DefaultColumnValues>
+        </pnp:ListInstance>
+      </pnp:Lists>
+    </pnp:ProvisioningTemplate>
+  </pnp:Templates>
+</pnp:Provisioning>";
+
+        [TestMethod]
+        public void DataSourceSurvivesATemplateRoundTrip()
+        {
+            ListInstance externalList = RoundTrip().Lists.First(l => l.Title == "Customers");
+
+            Assert.AreEqual(4, externalList.DataSource.Count, "the external list lost its DataSource entries");
+            Assert.AreEqual("ODS", externalList.DataSource["LobSystemInstance"]);
+            Assert.AreEqual("ODS.Customer", externalList.DataSource["Entity"]);
+        }
+
+        [TestMethod]
+        public void DefaultColumnValuesSurviveATemplateRoundTrip()
+        {
+            ListInstance library = RoundTrip().Lists.First(l => l.Title == "Documents");
+
+            Assert.AreEqual(2, library.DefaultColumnValues.Count, "the library lost its DefaultColumnValues entries");
+            Assert.AreEqual("Custom Value 1", library.DefaultColumnValues["Field1"]);
+        }
+
+        /// <summary>
+        /// A list that declares no DataSource has to come back without one, rather than with the
+        /// contents of the first other setting that happens to use the same schema item type.
+        /// </summary>
+        [TestMethod]
+        public void DefaultColumnValuesAreNotReadAsADataSource()
+        {
+            ProvisioningTemplate loaded = Load();
+            ListInstance library = loaded.Lists.First(l => l.Title == "Documents");
+
+            Assert.AreEqual(0, library.DataSource.Count, "DefaultColumnValues were read as a DataSource");
+        }
+
+        private static ProvisioningTemplate Load()
+        {
+            using var input = new MemoryStream(Encoding.UTF8.GetBytes(Template));
+            return XMLPnPSchemaFormatter.LatestFormatter.ToProvisioningTemplate(input);
+        }
+
+        private static ProvisioningTemplate RoundTrip()
+        {
+            var formatter = XMLPnPSchemaFormatter.LatestFormatter;
+            using var saved = formatter.ToFormattedTemplate(Load());
+            return formatter.ToProvisioningTemplate(saved);
+        }
+    }
+}

--- a/src/lib/PnP.Framework/Provisioning/Providers/Xml/Serializers/V202103/ListInstancesSerializer.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Xml/Serializers/V202103/ListInstancesSerializer.cs
@@ -101,14 +101,17 @@ namespace PnP.Framework.Provisioning.Providers.Xml.Serializers.V202103
                 var dataSourceItemType = Type.GetType(dataSourceItemTypeName, true);
                 var dataSourceItemKeySelector = CreateSelectorLambda(dataSourceItemType, "Key");
                 var dataSourceItemValueSelector = CreateSelectorLambda(dataSourceItemType, "Value");
-                expressions.Add(l => l.DataSource, new FromArrayToDictionaryValueResolver<string, string>(dataSourceItemType, dataSourceItemKeySelector, dataSourceItemValueSelector));
+                // DataSource and DefaultColumnValues are both StringDictionaryItem arrays, so the source
+                // property has to be named. Without it the resolver falls back to the first array of that
+                // item type on the list and the two settings read each other's values.
+                expressions.Add(l => l.DataSource, new FromArrayToDictionaryValueResolver<string, string>(dataSourceItemType, dataSourceItemKeySelector, dataSourceItemValueSelector, "DataSource"));
 
                 // Default Column Values
                 var defaultColumnItemTypeName = $"{PnPSerializationScope.Current?.BaseSchemaNamespace}.StringDictionaryItem, {PnPSerializationScope.Current?.BaseSchemaAssemblyName}";
                 var defaultColumnItemType = Type.GetType(defaultColumnItemTypeName, true);
                 var defaultColumnItemKeySelector = CreateSelectorLambda(defaultColumnItemType, "Key");
                 var defaultColumnItemValueSelector = CreateSelectorLambda(defaultColumnItemType, "Value");
-                expressions.Add(l => l.DefaultColumnValues, new FromArrayToDictionaryValueResolver<string, string>(defaultColumnItemType, defaultColumnItemKeySelector, defaultColumnItemValueSelector));
+                expressions.Add(l => l.DefaultColumnValues, new FromArrayToDictionaryValueResolver<string, string>(defaultColumnItemType, defaultColumnItemKeySelector, defaultColumnItemValueSelector, "DefaultColumnValues"));
 
                 template.Lists.AddRange(
                     PnPObjectsMapper.MapObjects<ListInstance>(lists,
@@ -210,6 +213,8 @@ namespace PnP.Framework.Provisioning.Providers.Xml.Serializers.V202103
                 var dataSourceItemType = Type.GetType(dataSourceItemTypeName, true);
                 var dataSourceItemKeySelector = CreateSelectorLambda(dataSourceItemType, "Key");
                 var dataSourceItemValueSelector = CreateSelectorLambda(dataSourceItemType, "Value");
+
+                resolvers.Add($"{listInstanceType}.DataSource", new FromDictionaryToArrayValueResolver<string, string>(dataSourceItemType, dataSourceItemKeySelector, dataSourceItemValueSelector));
 
                 // Default Column Values
                 var defaultColumnItemTypeName = $"{PnPSerializationScope.Current?.BaseSchemaNamespace}.StringDictionaryItem, {PnPSerializationScope.Current?.BaseSchemaAssemblyName}";


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Related issue

Fixes #1260

## What is in this Pull Request

Two problems in `Serializers/V202103/ListInstancesSerializer.cs`, the serializer selected for schema 2021-03 and 2022-09, so for anything current.

**1. `DataSource` was never written.** `Serialize` builds the item type and the key and value selectors and then never registers the resolver:

```csharp
// DataSource
var dataSourceItemType = Type.GetType(dataSourceItemTypeName, true);
var dataSourceItemKeySelector = CreateSelectorLambda(dataSourceItemType, "Key");
var dataSourceItemValueSelector = CreateSelectorLambda(dataSourceItemType, "Value");
                                             // <- no resolvers.Add, the three above are dead code

// Default Column Values
...
resolvers.Add($"{listInstanceType}.DefaultColumnValues", ...);
```

`V201705` and `V201909` both have `resolvers.Add($"{listInstanceType}.DataSource", ...)`. It was not carried over when the 2021-03 serializer was added, so reading a template and writing it back drops the BCS configuration of every external list in it. `Read-PnPSiteTemplate` followed by `Save-PnPSiteTemplate` is enough to lose it.

**2. `DefaultColumnValues` was read as a `DataSource`.** Both are `StringDictionaryItem[]` on the schema list type and neither resolver named its source property. When a list has no `DataSource`, `FromArrayToDictionaryValueResolver` falls back to "the first array property whose item type matches" and finds `DefaultColumnValues`:

```csharp
sourceValue = source.GetType().GetProperties().FirstOrDefault(sp => sp.PropertyType.IsArray &&
    sp.PropertyType.GetElementType().FullName == _sourceArrayItemType.FullName)?.GetValue(source);
```

Both resolvers now pass their source property name, which is the parameter that fallback already supports and that the `DataRows` resolver in the same file uses.

The two defects had been masking each other. Restoring the write path alone would have started writing the leaked values out as a `DataSource` the template never declared, so both belong in one change.

### Verification

Round trip of a template with one external list carrying four `DataSourceItem` entries and one library carrying `DefaultColumnValues` and no `DataSource`, through `XMLPnPSchemaFormatter.LatestFormatter`.

Before, the external list loses its BCS settings on save and the library picks up a `DataSource` it never declared:

![Before the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1260/datasource-before-fix.png)

After, the settings survive and stay where they belong:

![After the fix](https://raw.githubusercontent.com/svermaak/pnpframework/assets-1260/datasource-after-fix.png)

The repo's own `Resources/Templates/ProvisioningSchema-2022-09-FullSample-01.xml` behaves the same way: before this change its `Sample BCS List` came back from a round trip with no `DataSource`, and its `Projects` list came back with the default column values duplicated into `DataSource`.

Builds clean for `netstandard2.0`, `net8.0`, `net9.0` and `net10.0`.

### Regression test

`ListInstanceDataSourceTests` covers the three cases: `DataSource` survives a round trip, `DefaultColumnValues` survive a round trip, and `DefaultColumnValues` are not read as a `DataSource`. On `dev` the first and third fail, with this change all three pass.

The wider provider suite is unchanged: 451 passed, 15 failed before and after, the 15 being the `XMLProvidersTests` and `BaseTemplateTests` classes that need tenant details in `App.config`.

No CHANGELOG entry included.
