### PR TITLE
Fix for 1274 - Fixing publish option for template provisioning extraction

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ProvisioningTemplateCreationInformation.cs
@@ -31,8 +31,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         private bool includeContentTypesFromSyndication = true;
         private bool includeHiddenLists = false;
         private bool includeAllClientSidePages = false;
-
-
+        private bool extractPageAsPublished = true;
 
         /// <summary>
         /// Provisioning Progress Delegate
@@ -116,7 +115,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         }
 
         /// <summary>
-        /// Do composed look files (theme files, site logo, alternate css) need to be persisted to storage when 
+        /// Do composed look files (theme files, site logo, alternate css) need to be persisted to storage when
         /// we're "getting" a template
         /// </summary>
         [Obsolete("Use PersistBrandingFiles instead")]
@@ -326,6 +325,15 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         }
 
         /// <summary>
+        /// Declares whether Page templates should be extracted as Published or not
+        /// </summary>
+        public bool ExtractPageAsPublished
+        {
+            get => extractPageAsPublished;
+            set => extractPageAsPublished = value;
+        }
+
+        /// <summary>
         /// Optional argument to specify the collection of lists to extract
         /// </summary>
         /// <remarks>
@@ -337,7 +345,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
         /// List which contains information about resource tokens used and/or created during the extraction of a template.
         /// </summary>
         internal List<Tuple<string, int, string>> ResourceTokens { get; } = new List<Tuple<string, int, string>>();
-        
+
         /// <summary>
         /// Extraction configuration coming from JSON
         /// </summary>

--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -105,7 +105,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
                     extractedPageInstance.PromoteAsNewsArticle = isNews;
                     extractedPageInstance.PromoteAsTemplate = page.IsTemplate;
                     extractedPageInstance.Overwrite = true;
-                    extractedPageInstance.Publish = true;
+                    extractedPageInstance.Publish = creationInfo.ExtractPageAsPublished;
                     extractedPageInstance.Layout = pageToExtract.LayoutType.ToString();
                     //extractedPageInstance.EnableComments = !pageToExtract.CommentsDisabled;
                     extractedPageInstance.EnableComments = !pageToExtract.AreCommentsDisabled();


### PR DESCRIPTION
Related issue:
https://github.com/pnp/pnpframework/issues/1274 - Provisioning - Template extraction always sets page as Published

What is changed:
ProvisioningTemplateCreationInformation.cs - line 34 Added a propery that will control if extracted pages will be drafts or published. Defaults to state Published, to preserve original behavior.

ClientSidePageContentsHelper.cs - line 108, use value from template provisioning information object instead of setting to true.

Tests:
Not run in full, as many provisioning tests require installation of O365 Starter Intranet which is outdated/archived

Third public PR ever, please help me improve. :)

BR
Magnus