### PR TITLE
Fix for 1276 - Update JSON control data handling for web parts

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Utilities/ClientSidePageContentsHelper.cs
@@ -538,6 +538,22 @@ namespace PnP.Framework.Provisioning.ObjectHandlers.Utilities
             {
                 // If the JsonControlData is already set, we don't need to merge it with the propertiesJson
                 var json = Newtonsoft.Json.Linq.JObject.Parse(webPart.JsonControlData);
+
+                // BuildControlData uses the SharePoint canvas schema:
+                //   webPartId = component ID
+                //   id        = instance ID
+                //
+                // PnP provisioning templates expect:
+                //   id         = component ID
+                //   instanceId = instance ID
+                // Only normalize actual web parts. SectionBackgroundControl and other
+                // special canvas controls might not have a valid WebPartId.
+                if (Guid.TryParse(webPart.WebPartId, out _))
+                {
+                    json["id"] = webPart.WebPartId;
+                    json["instanceId"] = webPart.InstanceId.ToString("D");
+                }
+                
                 if (!string.IsNullOrWhiteSpace(webPart.PropertiesJson))
                     json.Add("properties", Newtonsoft.Json.Linq.JObject.Parse(webPart.PropertiesJson));
 


### PR DESCRIPTION
Normalize JSON control data for web parts in provisioning.
Adding instanceId to keep it during export.
 #1276 